### PR TITLE
BC: change API key header

### DIFF
--- a/src/hafnia/platform/api.py
+++ b/src/hafnia/platform/api.py
@@ -4,7 +4,7 @@ from hafnia.http import fetch
 
 
 def get_organization_id(endpoint: str, api_key: str) -> str:
-    headers = {"X-APIKEY": api_key}
+    headers = {"Authorization": api_key}
     try:
         org_info = fetch(endpoint, headers=headers)
     except urllib3.exceptions.HTTPError as e:

--- a/src/hafnia/platform/download.py
+++ b/src/hafnia/platform/download.py
@@ -30,7 +30,7 @@ def get_resource_creds(endpoint: str, api_key: str) -> Dict[str, Any]:
         RuntimeError: If the call to fetch the credentials fails for any reason.
     """
     try:
-        creds = fetch(endpoint, headers={"X-APIKEY": api_key, "accept": "application/json"})
+        creds = fetch(endpoint, headers={"Authorization": api_key, "accept": "application/json"})
         logger.debug("Successfully retrieved credentials from DIP endpoint.")
         return creds
     except Exception as e:

--- a/src/hafnia/platform/experiment.py
+++ b/src/hafnia/platform/experiment.py
@@ -7,7 +7,7 @@ from hafnia.utils import archive_dir, get_recipe_path
 
 
 def get_dataset_id(dataset_name: str, endpoint: str, api_key: str) -> Optional[str]:
-    headers = {"X-APIKEY": api_key}
+    headers = {"Authorization": api_key}
     full_url = f"{endpoint}?name__iexact={dataset_name}"
     dataset_info = fetch(full_url, headers=headers)
     if not dataset_info:
@@ -16,7 +16,7 @@ def get_dataset_id(dataset_name: str, endpoint: str, api_key: str) -> Optional[s
 
 
 def create_recipe(source_dir: Path, endpoint: str, api_key: str, organization_id: str) -> Optional[str]:
-    headers = {"X-APIKEY": api_key, "accept": "application/json"}
+    headers = {"Authorization": api_key, "accept": "application/json"}
     source_dir = source_dir.resolve()  # Ensure the path is absolute to handle '.' paths are given an appropriate name.
     path_recipe = get_recipe_path(recipe_name=source_dir.name)
     zip_path = archive_dir(source_dir, output_path=path_recipe)
@@ -36,7 +36,7 @@ def create_recipe(source_dir: Path, endpoint: str, api_key: str, organization_id
 
 
 def get_exp_environment_id(name: str, endpoint: str, api_key: str) -> Optional[str]:
-    headers = {"X-APIKEY": api_key}
+    headers = {"Authorization": api_key}
     env_info = fetch(endpoint, headers=headers)
     return next((env["id"] for env in env_info if env["name"] == name), None)
 
@@ -51,7 +51,7 @@ def create_experiment(
     api_key: str,
     organization_id: str,
 ) -> Optional[str]:
-    headers = {"X-APIKEY": api_key}
+    headers = {"Authorization": api_key}
     response = post(
         endpoint,
         headers=headers,


### PR DESCRIPTION
This is a breaking change. The API key is moved to `Authorization` header and it should have `ApiKey` as the scheme.
For example: `Authorization: ApiKey some-key`