### PR TITLE
Change function name from 'is_remote_job()' to 'is_hafnia_cloud_job'

### DIFF
--- a/src/hafnia/data/factory.py
+++ b/src/hafnia/data/factory.py
@@ -15,7 +15,7 @@ def load_dataset(recipe: Any, force_redownload: bool = False) -> HafniaDataset:
 
 
 def get_dataset_path(recipe: Any, force_redownload: bool = False) -> Path:
-    if utils.is_remote_job():
+    if utils.is_hafnia_cloud_job():
         return Path(os.getenv("MDI_DATASET_DIR", "/opt/ml/input/data/training"))
 
     path_dataset = get_or_create_dataset_path_from_recipe(recipe, force_redownload=force_redownload)

--- a/src/hafnia/experiment/hafnia_logger.py
+++ b/src/hafnia/experiment/hafnia_logger.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, field_validator
 from hafnia.data.factory import load_dataset
 from hafnia.dataset.hafnia_dataset import HafniaDataset
 from hafnia.log import sys_logger, user_logger
-from hafnia.utils import is_remote_job, now_as_str
+from hafnia.utils import is_hafnia_cloud_job, now_as_str
 
 
 class EntityType(Enum):
@@ -101,7 +101,7 @@ class HafniaLogger:
 
     def path_local_experiment(self) -> Path:
         """Get the path for local experiment."""
-        if is_remote_job():
+        if is_hafnia_cloud_job():
             raise RuntimeError("Cannot access local experiment path in remote job.")
         return self._local_experiment_path
 
@@ -110,7 +110,7 @@ class HafniaLogger:
         if "MDI_CHECKPOINT_DIR" in os.environ:
             return Path(os.environ["MDI_CHECKPOINT_DIR"])
 
-        if is_remote_job():
+        if is_hafnia_cloud_job():
             return Path("/opt/ml/checkpoints")
         return self.path_local_experiment() / "checkpoints"
 
@@ -119,7 +119,7 @@ class HafniaLogger:
         if "MDI_ARTIFACT_DIR" in os.environ:
             return Path(os.environ["MDI_ARTIFACT_DIR"])
 
-        if is_remote_job():
+        if is_hafnia_cloud_job():
             return Path("/opt/ml/output/data")
 
         return self.path_local_experiment() / "data"
@@ -129,7 +129,7 @@ class HafniaLogger:
         if "MDI_MODEL_DIR" in os.environ:
             return Path(os.environ["MDI_MODEL_DIR"])
 
-        if is_remote_job():
+        if is_hafnia_cloud_job():
             return Path("/opt/ml/model")
 
         return self.path_local_experiment() / "model"

--- a/src/hafnia/utils.py
+++ b/src/hafnia/utils.py
@@ -133,7 +133,7 @@ def show_recipe_content(recipe_path: Path, style: str = "emoji", depth_limit: in
     user_logger.info(f"Recipe size: {size_human_readable(os.path.getsize(recipe_path))}. Max size 800 MiB")
 
 
-def is_remote_job() -> bool:
+def is_hafnia_cloud_job() -> bool:
     """Check if the current job is running in HAFNIA cloud environment."""
     return os.getenv("HAFNIA_CLOUD", "false").lower() == "true"
 


### PR DESCRIPTION
Change function name from `is_remote_job()` to `is_hafnia_cloud_job()`. I want to expose this to the user and in the recipe-script . But before I do that, I want to make it less generic. 