### PR TITLE
Autofix api key and fix S3 rate limit issue

### DIFF
--- a/examples/example_dataset_recipe.py
+++ b/examples/example_dataset_recipe.py
@@ -29,20 +29,24 @@ dataset_recipe = DatasetRecipe.from_name(name="mnist").shuffle().select_samples(
 dataset = dataset_recipe.build()
 # Note that the interface is similar, but to actually create the dataset you need to call `build()` on the recipe.
 
-# An important feature of a 'DatasetRecipe' is that the recipe itself - and not the dataset - can be saved as a file
-# and loaded from file. Meaning you can easily save, share, load and build the dataset later or in a different
-# environment.
-# In programming language, the recipe can be serialized to JSON and deserialized back to the original python object
-# recipe.
+# Unlike the HafniaDataset, a DatasetRecipe does not execute operations. It only registers
+# the operations applied to the recipe and can be used to build the dataset later.
+# You can print the dataset recipe to the operations that were applied to it.
+rprint(dataset_recipe)
+
+# Or as a JSON string:
+json_str: str = dataset_recipe.as_json_str()
+rprint(json_str)
+
+# This is an important feature of a 'DatasetRecipe' it only registers operations and that the recipe itself
+# - and not the dataset - can be saved as a file and loaded from file.
+# Meaning you can easily save, share, load and build the dataset later or in a different environment.
 # For TaaS, this is the only way to include multiple datasets during training.
 
-# This is how it looks like in practice:
-# 1) Save the dataset recipe to a file
-path_json = Path(".data/tmp/dataset_recipe.json")
-dataset_recipe.as_json_file(path_json)
 
-# 2) The recipe can be loaded from the file
-dataset_recipe_again = DatasetRecipe.from_json_file(path_json)
+# 2) The recipe can be loaded from json string
+dataset_recipe_again: DatasetRecipe = DatasetRecipe.from_json_str(json_str)
+# dataset_recipe_again.build()
 
 # We can verify that the loaded recipe is the same as the original recipe.
 assert dataset_recipe_again == dataset_recipe

--- a/src/cli/__main__.py
+++ b/src/cli/__main__.py
@@ -20,19 +20,15 @@ def configure(cfg: Config) -> None:
 
     profile_name = click.prompt("Profile Name", type=str, default=consts.DEFAULT_PROFILE_NAME)
     profile_name = profile_name.strip()
-    try:
-        cfg.add_profile(profile_name, ConfigSchema(), set_active=True)
-    except ValueError:
-        raise click.ClickException(consts.ERROR_CREATE_PROFILE)
+
+    cfg.check_profile_name(profile_name)
 
     api_key = click.prompt("Hafnia API Key", type=str, hide_input=True)
-    try:
-        cfg.api_key = api_key.strip()
-    except ValueError as e:
-        click.echo(f"Error: {str(e)}", err=True)
-        return
+
     platform_url = click.prompt("Hafnia Platform URL", type=str, default=consts.DEFAULT_API_URL)
-    cfg.platform_url = platform_url.strip()
+
+    cfg_profile = ConfigSchema(api_key=api_key, platform_url=platform_url)
+    cfg.add_profile(profile_name, cfg_profile, set_active=True)
     cfg.save_config()
     profile_cmds.profile_show(cfg)
 

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, field_validator
 
 import cli.consts as consts
-from hafnia.log import user_logger
+from hafnia.log import sys_logger, user_logger
 
 PLATFORM_API_MAPPING = {
     "recipes": "/api/v1/recipes",
@@ -23,10 +23,15 @@ class ConfigSchema(BaseModel):
     api_key: Optional[str] = None
 
     @field_validator("api_key")
-    def validate_api_key(cls, value: str) -> str:
-        if value is not None and len(value) < 10:
+    def validate_api_key(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+
+        if len(value) < 10:
             raise ValueError("API key is too short.")
+
         if not value.startswith("ApiKey "):
+            sys_logger.warning("API key is missing the 'ApiKey ' prefix. Prefix is being added automatically.")
             value = f"ApiKey {value}"
 
         return value

--- a/src/cli/profile_cmds.py
+++ b/src/cli/profile_cmds.py
@@ -56,6 +56,7 @@ def profile_create(cfg: Config, name: str, api_url: str, api_key: str, activate:
     cfg_profile = ConfigSchema(platform_url=api_url, api_key=api_key)
 
     cfg.add_profile(profile_name=name, profile=cfg_profile, set_active=activate)
+    profile_show(cfg)
 
 
 @profile.command("rm")
@@ -87,7 +88,7 @@ def profile_active(cfg: Config) -> None:
 
 
 def profile_show(cfg: Config) -> None:
-    masked_key = f"{cfg.api_key[:4]}...{cfg.api_key[-4:]}" if len(cfg.api_key) > 8 else "****"
+    masked_key = f"{cfg.api_key[:11]}...{cfg.api_key[-4:]}" if len(cfg.api_key) > 20 else "****"
     console = Console()
 
     table = Table(title=f"{consts.PROFILE_TABLE_HEADER} {cfg.active_profile}", show_header=False)

--- a/src/hafnia/dataset/dataset_recipe/dataset_recipe.py
+++ b/src/hafnia/dataset/dataset_recipe/dataset_recipe.py
@@ -292,7 +292,7 @@ class FromPath(RecipeCreation):
         return HafniaDataset.from_path
 
     def as_short_name(self) -> str:
-        return f"'{self.path_folder}'".replace(os.sep, "|")
+        return f"'{self.path_folder}'".replace(os.sep, "-")
 
     def get_dataset_names(self) -> List[str]:
         return []  # Only counts 'from_name' datasets

--- a/src/hafnia/dataset/dataset_recipe/recipe_types.py
+++ b/src/hafnia/dataset/dataset_recipe/recipe_types.py
@@ -108,6 +108,10 @@ class RecipeCreation(Serializable):
     def get_function() -> Callable[..., "HafniaDataset"]:
         pass
 
+    @abstractmethod
+    def get_dataset_names(self) -> List[str]:
+        pass
+
     def build(self) -> "HafniaDataset":
         from hafnia.dataset.dataset_recipe.dataset_recipe import DatasetRecipe
 

--- a/src/hafnia/platform/datasets.py
+++ b/src/hafnia/platform/datasets.py
@@ -62,7 +62,11 @@ def download_or_get_dataset_path(
     dataset_id = get_dataset_id(dataset_name=dataset_name, endpoint=endpoint_dataset, api_key=api_key)
     if dataset_id is None:
         sys_logger.error(f"Dataset '{dataset_name}' not found on the Hafnia platform.")
-    access_dataset_endpoint = f"{endpoint_dataset}/{dataset_id}/temporary-credentials"
+
+    if utils.is_hafnia_cloud_job():
+        access_dataset_endpoint = f"{endpoint_dataset}/{dataset_id}/temporary-credentials-hidden"
+    else:
+        access_dataset_endpoint = f"{endpoint_dataset}/{dataset_id}/temporary-credentials"
 
     download_dataset_from_access_endpoint(
         endpoint=access_dataset_endpoint,

--- a/src/hafnia/platform/datasets.py
+++ b/src/hafnia/platform/datasets.py
@@ -64,9 +64,10 @@ def download_or_get_dataset_path(
         sys_logger.error(f"Dataset '{dataset_name}' not found on the Hafnia platform.")
 
     if utils.is_hafnia_cloud_job():
-        access_dataset_endpoint = f"{endpoint_dataset}/{dataset_id}/temporary-credentials-hidden"
+        credentials_endpoint_suffix = "temporary-credentials-hidden"  # Access to hidden datasets
     else:
-        access_dataset_endpoint = f"{endpoint_dataset}/{dataset_id}/temporary-credentials"
+        credentials_endpoint_suffix = "temporary-credentials"  # Access to sample dataset
+    access_dataset_endpoint = f"{endpoint_dataset}/{dataset_id}/{credentials_endpoint_suffix}"
 
     download_dataset_from_access_endpoint(
         endpoint=access_dataset_endpoint,

--- a/tests/dataset/dataset_recipe/test_dataset_recipes.py
+++ b/tests/dataset/dataset_recipe/test_dataset_recipes.py
@@ -173,7 +173,7 @@ class IntegrationTestUseCase:
         ),
         IntegrationTestUseCase(
             recipe=DatasetRecipe.from_path(path_folder=Path(".data/datasets/mnist"), check_for_images=False),
-            short_name="'.data|datasets|mnist'",
+            short_name="'.data-datasets-mnist'",
         ),
         IntegrationTestUseCase(
             recipe=DatasetRecipe.from_merger(
@@ -182,14 +182,14 @@ class IntegrationTestUseCase:
                     DatasetRecipe.from_path(path_folder=Path(".data/datasets/mnist"), check_for_images=False),
                 ]
             ),
-            short_name="Merger(mnist,'.data|datasets|mnist')",
+            short_name="Merger(mnist,'.data-datasets-mnist')",
         ),
         IntegrationTestUseCase(
             recipe=DatasetRecipe.from_merge(
                 recipe0=DatasetRecipe.from_path(path_folder=Path(".data/datasets/mnist"), check_for_images=False),
                 recipe1=DatasetRecipe.from_name(name="mnist", force_redownload=False),
             ),
-            short_name="Merger('.data|datasets|mnist',mnist)",
+            short_name="Merger('.data-datasets-mnist',mnist)",
         ),
         IntegrationTestUseCase(
             recipe=DatasetRecipe.from_name(name="mnist", force_redownload=False)

--- a/tests/dataset/test_dataset_helpers.py
+++ b/tests/dataset/test_dataset_helpers.py
@@ -72,8 +72,13 @@ def test_create_split_name_list_from_ratios(test_case: CreateSplitNameListFromRa
 
 def test_save_image_with_hash_name(tmp_path: Path):
     dummy_image = (255 * np.random.rand(100, 100, 3)).astype(np.uint8)  # Create a dummy image
-    path_image = dataset_helpers.save_image_with_hash_name(dummy_image, tmp_path)
-    filename_from_path = dataset_helpers.filename_as_hash_from_path(path_image)
-    assert filename_from_path == path_image.name
-    assert path_image.exists()
-    assert path_image.suffix in [".png"]
+    tmp_path0 = tmp_path / "folder0"
+    path_image0 = dataset_helpers.save_image_with_hash_name(dummy_image, tmp_path0)
+
+    tmp_path1 = tmp_path / "folder1"
+    path_image1 = dataset_helpers.copy_and_rename_file_to_hash_value(path_image0, tmp_path1)
+    assert path_image1.relative_to(tmp_path1) == path_image0.relative_to(tmp_path0)
+    assert path_image0.exists()
+    assert path_image1.exists()
+    assert path_image0.suffix in [".png"]
+    assert path_image1.suffix in [".png"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,10 +55,12 @@ def test_configure(cli_runner: CliRunner, empty_config: Config, api_key: str) ->
 
 
 def test_configure_api_key_autofix(cli_runner: CliRunner, empty_config: Config, api_key: str) -> None:
-    # The submitted api should always contain an "ApiKey " prefix.
-    # Namely the submitted api key should be in this form "ApiKey [API_KEY]"
-    # Many users submit the api key without the prefix.
-    # This test ensures that the CLI will automatically add the prefix if it is missing.
+    """
+    The submitted api key should always contain an "ApiKey " prefix.
+    Namely the submitted api key should be in this form "ApiKey [HASH_VALUE]"
+    Many users submit the api key without the prefix.
+    This test ensures that the CLI will automatically add the prefix if missing.
+    """
     inputs = f"default\nfake-api-key-with-out-prefix\n{consts.DEFAULT_API_URL}\n"
     result = cli_runner.invoke(cli.main, ["configure"], input="".join(inputs))
     assert result.exit_code == 0

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,3 +1,5 @@
+import collections
+from pathlib import Path
 from typing import Any, Dict
 
 import numpy as np
@@ -93,6 +95,11 @@ def test_check_dataset(loaded_dataset, compare_to_expected_image):
     image = sample.draw_annotations()
 
     compare_to_expected_image(image)
+
+    # We are arranging dataset files in multiple sub-folders to avoid S3 rate limits.
+    # This test checks that the dataset files are distributed across multiple sub-folders.
+    unique_sub_folders = collections.Counter([Path(path).parent.name for path in dataset.samples[ColumnName.FILE_NAME]])
+    assert len(unique_sub_folders) > 1, "Expected dataset files to be distributed across sub-folders"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This PR fixes two issues:
1) Issue 1: When users submit an api key through either `hafnia configure` or `hafnia profile create`, they should include `ApiKey ` before the hash value. Namely the full ApiKey has the following form `ApiKey [HASH_STR]` e.g. `ApiKey 2zuu1eR8*****yx0U3`. We have however found that multiple users are assuming that the api key should be submitted without the `ApiKey ` prefix. This will break the configuration and it is hard for our users to resolve the issue on their own afterwards. This PR includes a simple fix that automatically prefixes an api key with `ApiKey ` if missing. 
2) Issue 2: With the new Hafnia Dataset format, we are now storing individual images (previously images were packaged inside a binary/arrow format) causing each dataset to contain up to have 10,000s-100.000s of files. With many small files, we are unfortunately hitting a limit with S3 as we are "only" allowed to do 3500 ops/sec per prefix... Meaning we can "only" download 3500 files per sec. That sounds like a lot, but because `s5cmd` can actually download 1500-2000 files per second, we are hitting this limit with only 2 or 3 current experiments. To solve the issue, we are (instead of storing all images in a single folder) storing images into sub-folders using the image hash. E.g. "ad23fd34.png" will be stored as "ad2/3fd34.png" effectively storing images across 4094 sub-folders... Which allows the dataset to be fetch concurrently by 100s users
3) We have also changed the file hash name length from 64 to 128 bits to reduce risk of collision for very large datasets
4) Fix issues for the short_name of recipe in windows. The `DatasetRecipe.FromPath` was not working in windows. 