### PR TITLE
Bypass CI/CD check

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# Ignore 'CVE-2024-37059' issue https://avd.aquasec.com/nvd/2024/cve-2024-37059/
+# The vulnerability does not apply to our platform as models are not loaded on our platform.
+CVE-2024-37059

--- a/src/hafnia/dataset/dataset_recipe/dataset_recipe.py
+++ b/src/hafnia/dataset/dataset_recipe/dataset_recipe.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from pydantic import (
     field_serializer,
@@ -273,7 +273,7 @@ class DatasetRecipe(Serializable):
 
     def class_mapper(
         recipe: DatasetRecipe,
-        class_mapping: Dict[str, str],
+        class_mapping: Union[Dict[str, str], List[Tuple[str, str]]],
         method: str = "strict",
         primitive: Optional[Type[Primitive]] = None,
         task_name: Optional[str] = None,


### PR DESCRIPTION
To bypass vulnerability raised by Security Scan https://avd.aquasec.com/nvd/2024/cve-2024-37059/ . The vulnerability happens when models are being loaded. Currently, we don't load models - actually we don't even save models on MLFlow - so this is not a vulnability on the platform