### PR TITLE
Hide Secrets in github actions

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -11,7 +11,7 @@ from hafnia.log import sys_logger, user_logger
 
 PLATFORM_API_MAPPING = {
     "trainers": "/api/v1/trainers",
-    "dataset_recipes": "/api/v1/dataset-recipes",  # DONT COMMIT THIS!!!
+    "dataset_recipes": "/api/v1/dataset-recipes",
     "experiments": "/api/v1/experiments",
     "experiment_environments": "/api/v1/experiment-environments",
     "experiment_runs": "/api/v1/experiment-runs",

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -11,13 +11,21 @@ from hafnia.log import sys_logger, user_logger
 
 PLATFORM_API_MAPPING = {
     "trainers": "/api/v1/trainers",
-    "dataset_recipes": "/api/v1/dataset-recipes",
+    "dataset_recipes": "/api/v1/dataset-recipes",  # DONT COMMIT THIS!!!
     "experiments": "/api/v1/experiments",
     "experiment_environments": "/api/v1/experiment-environments",
     "experiment_runs": "/api/v1/experiment-runs",
     "runs": "/api/v1/experiments-runs",
     "datasets": "/api/v1/datasets",
 }
+
+
+class SecretStr(str):
+    def __repr__(self):
+        return "********"
+
+    def __str__(self):
+        return "********"
 
 
 class ConfigSchema(BaseModel):
@@ -37,7 +45,7 @@ class ConfigSchema(BaseModel):
             sys_logger.warning("API key is missing the 'ApiKey ' prefix. Prefix is being added automatically.")
             value = f"ApiKey {value}"
 
-        return value
+        return SecretStr(value)  # Keeps the API key masked in logs and repr
 
 
 class ConfigFileSchema(BaseModel):

--- a/tests/integration/test_dataset_recipes_with_platform.py
+++ b/tests/integration/test_dataset_recipes_with_platform.py
@@ -20,7 +20,8 @@ def test_dataset_recipe_on_platform():
 
     # Prepare test
     cfg = Config()
-    endpoint = cfg.get_platform_endpoint("dataset_recipes")
+    # endpoint = cfg.get_platform_endpoint("dataset_recipes")
+    endpoint = cfg.platform_url + "/api/v1/dataset-recipes123"
     dataset_recipe_name = "test-complex-recipe"
     # Ensure dataset recipe is deleted before test
     delete_dataset_recipe_by_name(name=dataset_recipe_name, endpoint=endpoint, api_key=cfg.api_key)

--- a/tests/integration/test_dataset_recipes_with_platform.py
+++ b/tests/integration/test_dataset_recipes_with_platform.py
@@ -20,8 +20,7 @@ def test_dataset_recipe_on_platform():
 
     # Prepare test
     cfg = Config()
-    # endpoint = cfg.get_platform_endpoint("dataset_recipes")
-    endpoint = cfg.platform_url + "/api/v1/dataset-recipes123"
+    endpoint = cfg.get_platform_endpoint("dataset_recipes")
     dataset_recipe_name = "test-complex-recipe"
     # Ensure dataset recipe is deleted before test
     delete_dataset_recipe_by_name(name=dataset_recipe_name, endpoint=endpoint, api_key=cfg.api_key)


### PR DESCRIPTION
We have an issue with tokens being displayed for failing integration tests. 
This PR ensures, that this will not happen again. The first CI/CD run (on the commit called "Fix" b23341e) shows that the api key has been successfully hidden. 