### PR TITLE
Support single copy for dataset recipes

### DIFF
--- a/src/hafnia/dataset/dataset_helpers.py
+++ b/src/hafnia/dataset/dataset_helpers.py
@@ -142,29 +142,6 @@ def copy_and_rename_file_to_hash_value(
     return path_file
 
 
-def copy_file_to_folder(
-    path_src_file: Path,
-    path_dst_folder: Path,
-    allow_skip: bool = True,
-) -> Path:
-    """
-    Copies a file to a dataset root directory preserving its original filename.
-    """
-    if not path_src_file.exists():
-        raise FileNotFoundError(f"Source file {path_src_file} does not exist.")
-
-    path_dst_file = path_dst_folder / path_src_file.name
-    path_dst_file.parent.mkdir(parents=True, exist_ok=True)
-
-    if allow_skip and path_dst_file.exists():
-        return path_dst_file
-
-    if path_src_file == path_dst_file:
-        return path_dst_file
-    shutil.copy2(path_src_file, path_dst_file)
-    return path_dst_file
-
-
 def relative_path_from_hash(hash: str, suffix: str) -> str:
     return f"{hash}{suffix}"
 

--- a/src/hafnia/dataset/dataset_helpers.py
+++ b/src/hafnia/dataset/dataset_helpers.py
@@ -118,7 +118,11 @@ def save_pil_image_with_hash_name(
     return path_image
 
 
-def copy_and_rename_file_to_hash_value(path_source: Path, path_dataset_root: Path) -> Path:
+def copy_and_rename_file_to_hash_value(
+    path_source: Path,
+    path_dataset_root: Path,
+    allow_skip: bool = True,
+) -> Path:
     """
     Copies a file to a dataset root directory with a hash-based name and sub-directory structure.
     """
@@ -129,10 +133,36 @@ def copy_and_rename_file_to_hash_value(path_source: Path, path_dataset_root: Pat
     hash_value = hash_file_xxhash(path_source)
     path_file = path_dataset_root / relative_path_from_hash(hash=hash_value, suffix=path_source.suffix)
     path_file.parent.mkdir(parents=True, exist_ok=True)
-    if not path_file.exists():
-        shutil.copy2(path_source, path_file)
+
+    if allow_skip and path_file.exists():
+        return path_file
+
+    shutil.copy2(path_source, path_file)
 
     return path_file
+
+
+def copy_file_to_folder(
+    path_src_file: Path,
+    path_dst_folder: Path,
+    allow_skip: bool = True,
+) -> Path:
+    """
+    Copies a file to a dataset root directory preserving its original filename.
+    """
+    if not path_src_file.exists():
+        raise FileNotFoundError(f"Source file {path_src_file} does not exist.")
+
+    path_dst_file = path_dst_folder / path_src_file.name
+    path_dst_file.parent.mkdir(parents=True, exist_ok=True)
+
+    if allow_skip and path_dst_file.exists():
+        return path_dst_file
+
+    if path_src_file == path_dst_file:
+        return path_dst_file
+    shutil.copy2(path_src_file, path_dst_file)
+    return path_dst_file
 
 
 def relative_path_from_hash(hash: str, suffix: str) -> str:

--- a/src/hafnia/dataset/dataset_recipe/dataset_recipe.py
+++ b/src/hafnia/dataset/dataset_recipe/dataset_recipe.py
@@ -33,8 +33,10 @@ class DatasetRecipe(Serializable):
     creation: RecipeCreation
     operations: Optional[List[RecipeTransform]] = None
 
-    def build(self) -> HafniaDataset:
-        dataset = self.creation.build()
+    def build(self, download_files: bool = True) -> HafniaDataset:
+        if hasattr(self.creation, "download_files"):
+            self.creation.download_files = download_files
+        dataset = self.creation.build(download_files=download_files)
         if self.operations:
             for operation in self.operations:
                 dataset = operation.build(dataset)
@@ -431,9 +433,9 @@ class FromMerge(RecipeCreation):
 class FromMerger(RecipeCreation):
     recipes: List[DatasetRecipe]
 
-    def build(self) -> HafniaDataset:
+    def build(self, download_files: bool = True) -> HafniaDataset:
         """Build the dataset from the merged recipes."""
-        datasets = [recipe.build() for recipe in self.recipes]
+        datasets = [recipe.build(download_files=download_files) for recipe in self.recipes]
         return self.get_function()(datasets=datasets)
 
     @staticmethod

--- a/src/hafnia/dataset/dataset_recipe/recipe_types.py
+++ b/src/hafnia/dataset/dataset_recipe/recipe_types.py
@@ -112,14 +112,14 @@ class RecipeCreation(Serializable):
     def get_dataset_names(self) -> List[str]:
         pass
 
-    def build(self) -> "HafniaDataset":
+    def build(self, download_files: bool = True) -> "HafniaDataset":
         from hafnia.dataset.dataset_recipe.dataset_recipe import DatasetRecipe
 
         kwargs = dict(self)
         kwargs_recipes_as_datasets = {}
         for key, value in kwargs.items():
             if isinstance(value, DatasetRecipe):
-                value = value.build()
+                value = value.build(download_files=download_files)
                 key = key.replace("recipe", "dataset")
             kwargs_recipes_as_datasets[key] = value
         return self.get_function()(**kwargs_recipes_as_datasets)

--- a/src/hafnia/dataset/hafnia_dataset.py
+++ b/src/hafnia/dataset/hafnia_dataset.py
@@ -524,8 +524,12 @@ class HafniaDataset:
         # Update dataset with new paths after download
         dataset.samples = dataset.samples.update(download_df, on=[SampleField.REMOTE_PATH])
 
-        # Extend 'download_df' with dataset name
-        download_samples = download_df.join(dataset.samples, on=SampleField.REMOTE_PATH, how="left")
+        # Extend 'download_df' with dataset name - but keep only unique remote paths to avoid duplicate downloads
+        download_samples = download_df.join(
+            dataset.samples.select([SampleField.REMOTE_PATH, SampleField.DATASET_NAME]),
+            on=SampleField.REMOTE_PATH,
+            how="left",
+        ).unique(subset=SampleField.REMOTE_PATH, keep="first")
         missing_samples = download_samples.filter(pl.col(MISSING_LOCALLY_COLUMN))
         existing_samples = download_samples.filter(pl.col(MISSING_LOCALLY_COLUMN) == False)  # noqa: E712
 

--- a/src/hafnia/dataset/hafnia_dataset.py
+++ b/src/hafnia/dataset/hafnia_dataset.py
@@ -45,7 +45,7 @@ from hafnia.dataset.primitives.primitive import Primitive
 from hafnia.log import user_logger
 from hafnia.platform import s5cmd_utils
 from hafnia.platform.datasets import get_read_credentials_by_name
-from hafnia.platform.s5cmd_utils import AwsCredentials, ResourceCredentials
+from hafnia.platform.s5cmd_utils import ResourceCredentials, fast_copy_files
 from hafnia.utils import progress_bar
 from hafnia_cli.config import Config
 
@@ -491,16 +491,14 @@ class HafniaDataset:
 
         return HafniaDataset(info=merged_info, samples=merged_samples)
 
-    def download_files_aws(
+    def download_files(
         dataset: HafniaDataset,
         path_output_folder: Path,
-        aws_credentials: AwsCredentials,
         force_redownload: bool = False,
         extend_name_by_subfolder: int = 0,
         subfolder_name: str = "data",
+        cfg: Optional[Config] = None,
     ) -> HafniaDataset:
-        from hafnia.platform.s5cmd_utils import fast_copy_files
-
         path_data = path_output_folder / subfolder_name
         path_data.mkdir(parents=True, exist_ok=True)
 
@@ -508,48 +506,62 @@ class HafniaDataset:
             raise ValueError(
                 f"'extend_name_by_subfolder' must be a non-negative integer. Got {extend_name_by_subfolder}."
             )
-        remote_src_paths = dataset.samples[SampleField.REMOTE_PATH].unique().to_list()
+        MISSING_LOCALLY_COLUMN = "MissingLocally"
         update_rows = []
-        local_dst_paths = []
-        for remote_src_path in remote_src_paths:
+        for remote_src_path in dataset.samples[SampleField.REMOTE_PATH].unique().to_list():
             path_parts = remote_src_path.split("/")
             filename = "_".join(path_parts[-(1 + extend_name_by_subfolder) :])
             local_path_str = (path_data / filename).absolute().as_posix()
-            local_dst_paths.append(local_path_str)
             update_rows.append(
                 {
                     SampleField.REMOTE_PATH: remote_src_path,
                     SampleField.FILE_PATH: local_path_str,
+                    MISSING_LOCALLY_COLUMN: not Path(local_path_str).exists(),
                 }
             )
-        update_df = pl.DataFrame(update_rows)
-        samples = dataset.samples.update(update_df, on=[SampleField.REMOTE_PATH])
-        dataset = dataset.update_samples(samples)
+        download_df = pl.DataFrame(update_rows)
 
-        if not force_redownload:
-            download_indices = [idx for idx, local_path in enumerate(local_dst_paths) if not Path(local_path).exists()]
-            n_files = len(local_dst_paths)
-            skip_files = n_files - len(download_indices)
-            if skip_files > 0:
-                user_logger.info(
-                    f"Found {skip_files}/{n_files} files already exists. Downloading {len(download_indices)} files."
-                )
-            remote_src_paths = [remote_src_paths[idx] for idx in download_indices]
-            local_dst_paths = [local_dst_paths[idx] for idx in download_indices]
+        # Update dataset with new paths after download
+        dataset.samples = dataset.samples.update(download_df, on=[SampleField.REMOTE_PATH])
 
-        if len(remote_src_paths) == 0:
+        # Extend 'download_df' with dataset name
+        download_samples = download_df.join(dataset.samples, on=SampleField.REMOTE_PATH, how="left")
+        missing_samples = download_samples.filter(pl.col(MISSING_LOCALLY_COLUMN))
+        existing_samples = download_samples.filter(pl.col(MISSING_LOCALLY_COLUMN) == False)  # noqa: E712
+
+        if not force_redownload and len(missing_samples) == 0:
             user_logger.info(
                 "All files already exist locally. Skipping download. Set 'force_redownload=True' to re-download."
             )
             return dataset
 
-        environment_vars = aws_credentials.aws_credentials()
-        fast_copy_files(
-            src_paths=remote_src_paths,
-            dst_paths=local_dst_paths,
-            append_envs=environment_vars,
-            description="Downloading images",
-        )
+        if force_redownload:
+            missing_samples = download_samples
+        else:
+            if len(existing_samples) > 0:
+                user_logger.info(
+                    f"Found {len(existing_samples)}/{len(download_samples)} files already exists. "
+                    f"Downloading {len(missing_samples)} files."
+                )
+
+        cfg = cfg or Config()
+        for (dataset_name,), dataset_group in missing_samples.group_by(SampleField.DATASET_NAME):
+            if dataset_name is None:
+                user_logger.warning(
+                    "Dataset name is missing in the samples. Cannot download files without dataset name."
+                )
+                continue
+            user_logger.info(f"Downloading files for dataset '{dataset_name}'...")
+            remote_src_paths = dataset_group[SampleField.REMOTE_PATH].to_list()
+            local_dst_paths = dataset_group[SampleField.FILE_PATH].to_list()
+            resource_credentials: ResourceCredentials = get_read_credentials_by_name(dataset_name=dataset_name, cfg=cfg)
+            environment_vars = resource_credentials.aws_credentials()
+            fast_copy_files(
+                src_paths=remote_src_paths,
+                dst_paths=local_dst_paths,
+                append_envs=environment_vars,
+                description="Downloading images",
+            )
         return dataset
 
     def to_dict_dataset_splits(self) -> Dict[str, "HafniaDataset"]:
@@ -623,7 +635,13 @@ class HafniaDataset:
             keep_sample_data=keep_sample_data,
         )
 
-    def write(self, path_folder: Path, drop_null_cols: bool = True) -> None:
+    def write(
+        self,
+        path_folder: Path,
+        drop_null_cols: bool = True,
+        rename_by_hash: bool = True,
+        allow_skip: bool = True,
+    ) -> None:
         user_logger.info(f"Writing dataset to {path_folder}...")
         path_folder = path_folder.absolute()
         if not path_folder.exists():
@@ -631,11 +649,19 @@ class HafniaDataset:
         hafnia_dataset = self.copy()  # To avoid inplace modifications
         new_paths = []
         org_paths = hafnia_dataset.samples[SampleField.FILE_PATH].to_list()
+        path_dataset_root = path_folder / "data"
+        path_dataset_root.mkdir(parents=True, exist_ok=True)
         for org_path in progress_bar(org_paths, description="- Copy images"):
-            new_path = dataset_helpers.copy_and_rename_file_to_hash_value(
-                path_source=Path(org_path),
-                path_dataset_root=path_folder / "data",
-            )
+            if rename_by_hash:
+                new_path = dataset_helpers.copy_and_rename_file_to_hash_value(
+                    path_source=Path(org_path),
+                    path_dataset_root=path_dataset_root,
+                    allow_skip=allow_skip,
+                )
+            else:
+                new_path = dataset_helpers.copy_file_to_folder(
+                    path_src_file=Path(org_path), path_dst_folder=path_dataset_root, allow_skip=allow_skip
+                )
             new_paths.append(new_path.as_posix())
         hafnia_dataset.samples = hafnia_dataset.samples.with_columns(pl.Series(new_paths).alias(SampleField.FILE_PATH))
         hafnia_dataset.write_annotations(path_folder=path_folder, drop_null_cols=drop_null_cols)
@@ -917,6 +943,6 @@ def download_or_get_dataset_path(
         return path_dataset
 
     dataset = HafniaDataset.from_path(path_dataset, check_for_images=False)
-    dataset = dataset.download_files_aws(path_dataset, aws_credentials=resource_credentials, force_redownload=True)
+    dataset = dataset.download_files(path_dataset, force_redownload=True)
     dataset.write_annotations(path_folder=path_dataset)  # Overwrite annotations as files have been re-downloaded
     return path_dataset

--- a/src/hafnia/dataset/hafnia_dataset.py
+++ b/src/hafnia/dataset/hafnia_dataset.py
@@ -639,13 +639,7 @@ class HafniaDataset:
             keep_sample_data=keep_sample_data,
         )
 
-    def write(
-        self,
-        path_folder: Path,
-        drop_null_cols: bool = True,
-        rename_by_hash: bool = True,  ## Use only rename_by_hash=False, when sample file names are unique.
-        allow_skip: bool = True,
-    ) -> None:
+    def write(self, path_folder: Path, drop_null_cols: bool = True) -> None:
         user_logger.info(f"Writing dataset to {path_folder}...")
         path_folder = path_folder.absolute()
         if not path_folder.exists():
@@ -653,21 +647,11 @@ class HafniaDataset:
         hafnia_dataset = self.copy()  # To avoid inplace modifications
         new_paths = []
         org_paths = hafnia_dataset.samples[SampleField.FILE_PATH].to_list()
-        path_dataset_root = path_folder / "data"
-        path_dataset_root.mkdir(parents=True, exist_ok=True)
         for org_path in progress_bar(org_paths, description="- Copy images"):
-            if rename_by_hash:
-                new_path = dataset_helpers.copy_and_rename_file_to_hash_value(
-                    path_source=Path(org_path),
-                    path_dataset_root=path_dataset_root,
-                    allow_skip=allow_skip,
-                )
-            else:
-                new_path = dataset_helpers.copy_file_to_folder(
-                    path_src_file=Path(org_path),
-                    path_dst_folder=path_dataset_root,
-                    allow_skip=allow_skip,
-                )
+            new_path = dataset_helpers.copy_and_rename_file_to_hash_value(
+                path_source=Path(org_path),
+                path_dataset_root=path_folder / "data",
+            )
             new_paths.append(new_path.as_posix())
         hafnia_dataset.samples = hafnia_dataset.samples.with_columns(pl.Series(new_paths).alias(SampleField.FILE_PATH))
         hafnia_dataset.write_annotations(path_folder=path_folder, drop_null_cols=drop_null_cols)

--- a/src/hafnia/dataset/hafnia_dataset.py
+++ b/src/hafnia/dataset/hafnia_dataset.py
@@ -643,7 +643,7 @@ class HafniaDataset:
         self,
         path_folder: Path,
         drop_null_cols: bool = True,
-        rename_by_hash: bool = True,
+        rename_by_hash: bool = True,  ## Use only rename_by_hash=False, when sample file names are unique.
         allow_skip: bool = True,
     ) -> None:
         user_logger.info(f"Writing dataset to {path_folder}...")
@@ -664,7 +664,9 @@ class HafniaDataset:
                 )
             else:
                 new_path = dataset_helpers.copy_file_to_folder(
-                    path_src_file=Path(org_path), path_dst_folder=path_dataset_root, allow_skip=allow_skip
+                    path_src_file=Path(org_path),
+                    path_dst_folder=path_dataset_root,
+                    allow_skip=allow_skip,
                 )
             new_paths.append(new_path.as_posix())
         hafnia_dataset.samples = hafnia_dataset.samples.with_columns(pl.Series(new_paths).alias(SampleField.FILE_PATH))

--- a/src/hafnia/dataset/operations/dataset_s3_storage.py
+++ b/src/hafnia/dataset/operations/dataset_s3_storage.py
@@ -188,6 +188,10 @@ def sync_dataset_files_to_platform_from_resource_credentials(
         else:
             dataset_variant = dataset
 
+        dataset_variant.samples = dataset_variant.samples.with_columns(
+            pl.lit(dataset.info.dataset_name).alias(SampleField.DATASET_NAME)
+        )
+
         sync_hafnia_dataset_to_s3(
             dataset=dataset_variant,
             bucket_prefix=f"s3://{bucket_name}/{dataset_variant_type.value}",

--- a/src/hafnia/experiment/command_builder.py
+++ b/src/hafnia/experiment/command_builder.py
@@ -42,8 +42,6 @@ from pydantic import BaseModel, ConfigDict, Field, create_model, model_validator
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
-from hafnia import utils
-
 DEFAULT_N_POSITIONAL_ARGS: int = 0
 DEFAULT_CASE_CONVERSION: Literal["none", "kebab"] = "none"
 DEFAULT_PARAMETER_PREFIX: str = "--"
@@ -54,6 +52,7 @@ DEFAULT_BOOL_HANDLING: Literal["none", "flag-negation"] = "none"
 
 def auto_save_command_builder_schema(
     cli_function: Callable[..., Any],
+    name: Optional[str] = None,
     n_positional_args: int = DEFAULT_N_POSITIONAL_ARGS,
     cli_tool: Optional[str] = "cyclopts",
     ignore_params: tuple[str, ...] = (),
@@ -95,6 +94,7 @@ def auto_save_command_builder_schema(
 
     launch_schema = CommandBuilderSchema.from_function(
         cli_function,
+        name=name,
         cli_tool=cli_tool,
         ignore_params=ignore_params,
         handle_union_types=handle_union_types,
@@ -228,6 +228,7 @@ class CommandBuilderSchema(BaseModel):
     @staticmethod
     def from_function(
         cli_function: Callable[..., Any],
+        name: Optional[str] = None,
         cli_tool: Optional[str] = "cyclopts",
         ignore_params: tuple[str, ...] = (),
         cmd: Optional[str] = None,
@@ -254,6 +255,7 @@ class CommandBuilderSchema(BaseModel):
             set_bool_handling = "flag-negation"
         else:
             raise ValueError(f"Unsupported cli_tool: {cli_tool}")
+        name = name or path_of_function(cli_function).as_posix()
 
         # Option to override individual settings
         set_case_conversion = case_conversion or set_case_conversion or DEFAULT_CASE_CONVERSION
@@ -270,7 +272,7 @@ class CommandBuilderSchema(BaseModel):
             handle_union_types=handle_union_types,
         )
         return CommandBuilderSchema(
-            name=utils.name_to_title(cli_function.__name__),
+            name=name,
             cmd=cmd,
             json_schema=function_schema,
             case_conversion=set_case_conversion,

--- a/tests/integration/test_recipe_download_logic.py
+++ b/tests/integration/test_recipe_download_logic.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+
+from hafnia.dataset.dataset_names import SampleField
+from hafnia.dataset.dataset_recipe.dataset_recipe import DatasetRecipe
+from hafnia.dataset.hafnia_dataset import HafniaDataset
+from hafnia.utils import is_hafnia_configured
+from tests.helper_testing_datasets import DATASET_SPEC_MNIST
+
+
+def test_recipe_download_files_with_write(tmp_path):
+    """
+    Verifies the logic used in the "fetching data" step. The main idea is to save resources by
+    only downloading files that are used in the final recipe (after merging and filtering) and
+    also avoiding unnecessary copy and hashing of files. We do this by combining
+
+    First skipping download with `download_files=False`, downloading to a specific path with `download_files(path)`
+    and then writing the dataset to a specific path with `allow_skip=True` and `rename_by_hash=False` to avoid
+    unnecessary copying and hashing of files that are already in the right place with the right name.
+
+    # Code snippet to be used in "fetching data" step in the recipe build logic:
+    dataset: HafniaDataset = recipe.build(download_files=False)
+    dataset = dataset.download_files(path_write)
+    dataset.write(path_write, rename_by_hash=False, allow_skip=True)
+    """
+    if not is_hafnia_configured():
+        pytest.skip("Hafnia platform not configured. Skipping recipe download logic test.")
+
+    recipe = DatasetRecipe.from_merge(
+        recipe0=DatasetRecipe.from_name(DATASET_SPEC_MNIST.name, version=DATASET_SPEC_MNIST.version),
+        recipe1=DatasetRecipe.from_name(DATASET_SPEC_MNIST.name, version=DATASET_SPEC_MNIST.version),
+    )
+
+    path_write = tmp_path / "write"
+
+    dataset: HafniaDataset = recipe.build(download_files=False)  # Images/videos are not downloaded yet
+    dataset = dataset.download_files(
+        path_write
+    )  # Now images are download to a single folder (avoid both a copy and downloading files that we don't need)
+
+    # All file paths should now exist locally
+    file_paths = dataset.samples[SampleField.FILE_PATH].to_list()
+    assert len(file_paths) > 0
+    for path in file_paths:
+        assert Path(path).exists(), f"Expected downloaded file to exist: {path}"
+
+    assert len(list(path_write.iterdir())) == 1, "Expect only 'data' folder in the download path"
+    dataset.write(path_write, rename_by_hash=False, allow_skip=False)
+    assert len(list(path_write.iterdir())) == 4, "Expect remaining files"
+
+    # Written files should preserve original filenames
+    written_dataset = HafniaDataset.from_path(path_write)
+    written_paths = written_dataset.samples[SampleField.FILE_PATH].to_list()
+    assert len(written_paths) == len(file_paths)
+    for written_path in written_paths:
+        assert Path(written_path).exists(), f"Expected written file to exist: {written_path}"

--- a/tests/integration/test_recipe_download_logic.py
+++ b/tests/integration/test_recipe_download_logic.py
@@ -12,21 +12,14 @@ from tests.helper_testing_datasets import DATASET_SPEC_MNIST
 def test_recipe_download_files_with_write(tmp_path):
     """
     Verifies the logic used in the "fetching data" step. The main idea is to save resources by
-    only downloading files that are used in the final recipe (after merging and filtering) and
-    also avoiding unnecessary copy and hashing of files.
+    only downloading files that are used in the final recipe (after merging and filtering) and also
+    avoids  hashing and coping of files by downloading files by saving only annotations to the same path.
 
-
-    We do this by combining the following steps:
-    1) Skipping initial download of dataset images/videos with `download_files=False`. Causing only
-       annotations / metadata to be downloaded.
-    2) Downloading images/videos to a specific path with `download_files(path)`
-    3) Writing the dataset to a specific path with `allow_skip=True` and `rename_by_hash=False` to avoid
-    unnecessary copying and hashing of files that are already in the right place with the right name.
 
     # Code snippet to be used in "fetching data" step in the recipe build logic:
     dataset: HafniaDataset = recipe.build(download_files=False)
     dataset = dataset.download_files(path_write)
-    dataset.write(path_write, rename_by_hash=False, allow_skip=True)
+    dataset.write_annotations(path_write)
     """
     if not is_hafnia_configured():
         pytest.skip("Hafnia platform not configured. Skipping recipe download logic test.")
@@ -50,7 +43,7 @@ def test_recipe_download_files_with_write(tmp_path):
         assert Path(path).exists(), f"Expected downloaded file to exist: {path}"
 
     assert len(list(path_write.iterdir())) == 1, "Expect only 'data' folder in the download path"
-    dataset.write(path_write, rename_by_hash=False, allow_skip=True)
+    dataset.write_annotations(path_write)
     assert len(list(path_write.iterdir())) == 4, "Expect remaining files"
 
     # Written files should preserve original filenames
@@ -59,3 +52,6 @@ def test_recipe_download_files_with_write(tmp_path):
     assert len(written_paths) == len(file_paths)
     for written_path in written_paths:
         assert Path(written_path).exists(), f"Expected written file to exist: {written_path}"
+
+    dataset_new = HafniaDataset.from_path(path_write)
+    dataset_new.check_dataset()

--- a/tests/integration/test_recipe_download_logic.py
+++ b/tests/integration/test_recipe_download_logic.py
@@ -13,10 +13,14 @@ def test_recipe_download_files_with_write(tmp_path):
     """
     Verifies the logic used in the "fetching data" step. The main idea is to save resources by
     only downloading files that are used in the final recipe (after merging and filtering) and
-    also avoiding unnecessary copy and hashing of files. We do this by combining
+    also avoiding unnecessary copy and hashing of files.
 
-    First skipping download with `download_files=False`, downloading to a specific path with `download_files(path)`
-    and then writing the dataset to a specific path with `allow_skip=True` and `rename_by_hash=False` to avoid
+
+    We do this by combining the following steps:
+    1) Skipping initial download of dataset images/videos with `download_files=False`. Causing only
+       annotations / metadata to be downloaded.
+    2) Downloading images/videos to a specific path with `download_files(path)`
+    3) Writing the dataset to a specific path with `allow_skip=True` and `rename_by_hash=False` to avoid
     unnecessary copying and hashing of files that are already in the right place with the right name.
 
     # Code snippet to be used in "fetching data" step in the recipe build logic:
@@ -46,7 +50,7 @@ def test_recipe_download_files_with_write(tmp_path):
         assert Path(path).exists(), f"Expected downloaded file to exist: {path}"
 
     assert len(list(path_write.iterdir())) == 1, "Expect only 'data' folder in the download path"
-    dataset.write(path_write, rename_by_hash=False, allow_skip=False)
+    dataset.write(path_write, rename_by_hash=False, allow_skip=True)
     assert len(list(path_write.iterdir())) == 4, "Expect remaining files"
 
     # Written files should preserve original filenames

--- a/tests/unit/test_command_builder.py
+++ b/tests/unit/test_command_builder.py
@@ -196,6 +196,7 @@ def test_command_builder_schema(tmp_path: Path):
     cli_function_example = example_advanced_cli_example()
     path_schema_json = tmp_path / "command_schema.json"
     auto_save_command_builder_schema(
+        name="Trainer",
         n_positional_args=0,
         cli_function=cli_function_example,
         path_schema=path_schema_json,
@@ -205,6 +206,7 @@ def test_command_builder_schema(tmp_path: Path):
 
     schema = CommandBuilderSchema.from_json_file(path_schema_json)
     schema.model_dump(mode="json")
+    assert schema.name == "Trainer"
 
 
 def test_command_builder_from_function():


### PR DESCRIPTION
The main idea of this PR is to support below code snippet in the "fetching data" step. The main idea is to save resources by only downloading files that are used in the final recipe (after merging and filtering) and also avoids  hashing and coping of files by downloading files and saving annotations to the same path. 

```python
dataset: HafniaDataset = recipe.build(download_files=False)
dataset = dataset.download_files(path_write)
dataset.write_annotations(path_write)
```
## Copilot
This PR extends Hafnia’s dataset/recipe workflow to support deferring file downloads and later downloading/writing datasets more efficiently, and updates the experiment command builder schema generation to support explicit naming.

Changes:

- Add optional name support to CommandBuilderSchema generation and persist it in saved schemas.
Thread a download_files flag through dataset recipe build logic to allow building recipes without downloading assets.
- Update dataset download/write helpers to support downloading into a target folder and writing datasets while optionally preserving original filenames and skipping copies.
