### PR TITLE
S3 interactions

### DIFF
--- a/src/hafnia/dataset/dataset_recipe/dataset_recipe.py
+++ b/src/hafnia/dataset/dataset_recipe/dataset_recipe.py
@@ -301,6 +301,22 @@ class DatasetRecipe(Serializable):
         recipe.append_operation(operation)
         return recipe
 
+    def drop_samples_by_class_name(
+        recipe: DatasetRecipe,
+        name: Union[List[str], str],
+        task_name: Optional[str] = None,
+        primitive: Optional[Type[Primitive]] = None,
+        drop_classes_from_task_info: bool = True,
+    ) -> DatasetRecipe:
+        operation = recipe_transforms.DropSamplesByClassName(
+            name=name,
+            task_name=task_name,
+            primitive=primitive,
+            drop_classes_from_task_info=drop_classes_from_task_info,
+        )
+        recipe.append_operation(operation)
+        return recipe
+
     ### Helper methods ###
     def get_dataset_names(self) -> List[str]:
         """

--- a/src/hafnia/dataset/dataset_recipe/recipe_transforms.py
+++ b/src/hafnia/dataset/dataset_recipe/recipe_transforms.py
@@ -95,3 +95,14 @@ class SelectSamplesByClassName(RecipeTransform):
     @staticmethod
     def get_function() -> Callable[..., "HafniaDataset"]:
         return HafniaDataset.select_samples_by_class_name
+
+
+class DropSamplesByClassName(RecipeTransform):
+    name: Union[List[str], str]
+    task_name: Optional[str] = None
+    primitive: Optional[Type[Primitive]] = None
+    drop_classes_from_task_info: bool = True
+
+    @staticmethod
+    def get_function() -> Callable[..., "HafniaDataset"]:
+        return HafniaDataset.drop_samples_by_class_name

--- a/src/hafnia/dataset/hafnia_dataset.py
+++ b/src/hafnia/dataset/hafnia_dataset.py
@@ -4,7 +4,7 @@ import copy
 from dataclasses import dataclass
 from pathlib import Path
 from random import Random
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import polars as pl
 from packaging.version import Version
@@ -45,9 +45,12 @@ from hafnia.dataset.primitives.primitive import Primitive
 from hafnia.log import user_logger
 from hafnia.platform import s5cmd_utils
 from hafnia.platform.datasets import get_read_credentials_by_name
-from hafnia.platform.s5cmd_utils import ResourceCredentials, fast_copy_files
+from hafnia.platform.s5cmd_utils import ResourceCredentials
 from hafnia.utils import progress_bar
 from hafnia_cli.config import Config
+
+if TYPE_CHECKING:
+    import boto3
 
 
 @dataclass
@@ -143,6 +146,66 @@ class HafniaDataset:
             download_files=download_files,
         )
         return HafniaDataset.from_path(dataset_path, check_for_images=download_files)
+
+    @staticmethod
+    def from_s3(
+        bucket_prefix: str,
+        path_local: Path,
+        session: "boto3.Session",
+        version: Optional[str] = None,
+        force_redownload: bool = False,
+    ) -> "HafniaDataset":
+        """Download a Hafnia dataset from a user-controlled S3 bucket.
+
+        Args:
+            bucket_prefix: S3 location without scheme, e.g. ``"my-bucket/sample"``.
+            path_local: Local folder to download into.
+            session: Boto3 session used to obtain credentials.
+            version: Dataset version string (e.g. ``"0.1.0"``) or ``None`` for latest.
+            force_redownload: If ``True``, re-download data files that already exist locally.
+        """
+        from hafnia.dataset.operations.dataset_s3_storage import download_dataset_from_s3
+
+        return download_dataset_from_s3(
+            bucket_prefix=bucket_prefix,
+            path_local=path_local,
+            session=session,
+            version=version,
+            force_redownload=force_redownload,
+        )
+
+    def to_s3(
+        self,
+        bucket_prefix: str,
+        session: "boto3.Session",
+        allow_version_overwrite: bool = False,
+        create_bucket_if_missing: bool = True,
+        interactive: bool = True,
+    ) -> None:
+        """Upload this dataset to a user-controlled S3 bucket.
+
+        Args:
+            bucket_prefix: S3 location without scheme, e.g. ``"my-bucket"`` or
+                ``"my-bucket/sample"``. The leading segment is treated as the
+                bucket name for the optional create step.
+            session: Boto3 session used to obtain credentials and (optionally)
+                create the bucket.
+            allow_version_overwrite: If ``True``, overwrite metadata files for an
+                existing version in S3.
+            create_bucket_if_missing: If ``True`` and the target bucket does not
+                exist, create it in the session's region before uploading.
+            interactive: If ``True``, prompt for confirmation before uploading.
+        """
+        from hafnia.dataset.operations.dataset_s3_storage import upload_dataset_to_s3
+
+        upload_dataset_to_s3(
+            dataset=self,
+            bucket_prefix=bucket_prefix,
+            session=session,
+            allow_version_overwrite=allow_version_overwrite,
+            create_bucket_if_missing=create_bucket_if_missing,
+            interactive=interactive,
+        )
 
     @staticmethod
     def from_samples_list(samples_list: List, info: DatasetInfo) -> "HafniaDataset":
@@ -469,6 +532,27 @@ class HafniaDataset:
             dataset=dataset, name=name, task_name=task_name, primitive=primitive
         )
 
+    def drop_samples_by_class_name(
+        dataset: HafniaDataset,
+        name: Union[List[str], str],
+        task_name: Optional[str] = None,
+        primitive: Optional[Type[Primitive]] = None,
+        drop_classes_from_task_info: bool = True,
+    ) -> HafniaDataset:
+        """
+        Drop samples that contain at least one annotation with the specified class name(s).
+        If 'task_name' and 'primitive' are not provided, the function will attempt to infer the task.
+        When 'drop_classes_from_task_info' is True, the specified class names are also removed
+        from the matching task in 'dataset.info.tasks' and class indices are re-assigned.
+        """
+        return dataset_transformations.drop_samples_by_class_name(
+            dataset=dataset,
+            name=name,
+            task_name=task_name,
+            primitive=primitive,
+            drop_classes_from_task_info=drop_classes_from_task_info,
+        )
+
     def merge(dataset0: "HafniaDataset", dataset1: "HafniaDataset") -> "HafniaDataset":
         """
         Merges two Hafnia datasets by concatenating their samples and updating the split names.
@@ -490,83 +574,6 @@ class HafniaDataset:
                 merged_info = merged_info.replace_task(old_task=task, new_task=None)
 
         return HafniaDataset(info=merged_info, samples=merged_samples)
-
-    def download_files(
-        dataset: HafniaDataset,
-        path_output_folder: Path,
-        force_redownload: bool = False,
-        extend_name_by_subfolder: int = 0,
-        subfolder_name: str = "data",
-        cfg: Optional[Config] = None,
-    ) -> HafniaDataset:
-        path_data = path_output_folder / subfolder_name
-        path_data.mkdir(parents=True, exist_ok=True)
-
-        if extend_name_by_subfolder < 0:
-            raise ValueError(
-                f"'extend_name_by_subfolder' must be a non-negative integer. Got {extend_name_by_subfolder}."
-            )
-        MISSING_LOCALLY_COLUMN = "MissingLocally"
-        update_rows = []
-        for remote_src_path in dataset.samples[SampleField.REMOTE_PATH].unique().to_list():
-            path_parts = remote_src_path.split("/")
-            filename = "_".join(path_parts[-(1 + extend_name_by_subfolder) :])
-            local_path_str = (path_data / filename).absolute().as_posix()
-            update_rows.append(
-                {
-                    SampleField.REMOTE_PATH: remote_src_path,
-                    SampleField.FILE_PATH: local_path_str,
-                    MISSING_LOCALLY_COLUMN: not Path(local_path_str).exists(),
-                }
-            )
-        download_df = pl.DataFrame(update_rows)
-
-        # Update dataset with new paths after download
-        dataset.samples = dataset.samples.update(download_df, on=[SampleField.REMOTE_PATH])
-
-        # Extend 'download_df' with dataset name - but keep only unique remote paths to avoid duplicate downloads
-        download_samples = download_df.join(
-            dataset.samples.select([SampleField.REMOTE_PATH, SampleField.DATASET_NAME]),
-            on=SampleField.REMOTE_PATH,
-            how="left",
-        ).unique(subset=SampleField.REMOTE_PATH, keep="first")
-        missing_samples = download_samples.filter(pl.col(MISSING_LOCALLY_COLUMN))
-        existing_samples = download_samples.filter(pl.col(MISSING_LOCALLY_COLUMN) == False)  # noqa: E712
-
-        if not force_redownload and len(missing_samples) == 0:
-            user_logger.info(
-                "All files already exist locally. Skipping download. Set 'force_redownload=True' to re-download."
-            )
-            return dataset
-
-        if force_redownload:
-            missing_samples = download_samples
-        else:
-            if len(existing_samples) > 0:
-                user_logger.info(
-                    f"Found {len(existing_samples)}/{len(download_samples)} files already exists. "
-                    f"Downloading {len(missing_samples)} files."
-                )
-
-        cfg = cfg or Config()
-        for (dataset_name,), dataset_group in missing_samples.group_by(SampleField.DATASET_NAME):
-            if dataset_name is None:
-                user_logger.warning(
-                    "Dataset name is missing in the samples. Cannot download files without dataset name."
-                )
-                continue
-            user_logger.info(f"Downloading files for dataset '{dataset_name}'...")
-            remote_src_paths = dataset_group[SampleField.REMOTE_PATH].to_list()
-            local_dst_paths = dataset_group[SampleField.FILE_PATH].to_list()
-            resource_credentials: ResourceCredentials = get_read_credentials_by_name(dataset_name=dataset_name, cfg=cfg)
-            environment_vars = resource_credentials.aws_credentials()
-            fast_copy_files(
-                src_paths=remote_src_paths,
-                dst_paths=local_dst_paths,
-                append_envs=environment_vars,
-                description="Downloading images",
-            )
-        return dataset
 
     def to_dict_dataset_splits(self) -> Dict[str, "HafniaDataset"]:
         """
@@ -902,6 +909,7 @@ def download_or_get_dataset_path(
     download_files: bool = True,
 ) -> Path:
     """Download or get the path of the dataset."""
+    from hafnia.dataset.operations.dataset_s3_storage import sync_files_from_platform
 
     path_datasets = path_datasets_folder or utils.PATH_DATASETS
     path_dataset = Path(path_datasets) / dataset_name
@@ -933,6 +941,6 @@ def download_or_get_dataset_path(
         return path_dataset
 
     dataset = HafniaDataset.from_path(path_dataset, check_for_images=False)
-    dataset = dataset.download_files(path_dataset, force_redownload=True)
+    dataset = sync_files_from_platform(dataset, path_dataset, force_redownload=True)
     dataset.write_annotations(path_folder=path_dataset)  # Overwrite annotations as files have been re-downloaded
     return path_dataset

--- a/src/hafnia/dataset/operations/dataset_s3_storage.py
+++ b/src/hafnia/dataset/operations/dataset_s3_storage.py
@@ -167,7 +167,7 @@ def upload_dataset_to_s3(
 
     sync_dataset_files_to_s3(
         dataset=dataset,
-        bucket_prefix=resource_credentials.s3_uri(),
+        bucket_prefix=resource_credentials.s3_path(),
         interactive=interactive,
         allow_version_overwrite=allow_version_overwrite,
         envs=envs,
@@ -182,7 +182,8 @@ def sync_dataset_files_to_s3(
     envs: Optional[Dict[str, str]] = None,
 ) -> None:
     t0 = time.time()
-    # bucket_prefix e.g. 's3://bucket-name/sample'
+    # bucket_prefix e.g. 'bucket-name/sample' (no scheme)
+    s3_uri_prefix = f"s3://{bucket_prefix}"
     remote_paths = []
     for file_str in progress_bar(dataset.samples[SampleField.FILE_PATH], description="Hashing data files"):
         path_file = Path(file_str)
@@ -192,13 +193,13 @@ def sync_dataset_files_to_s3(
         relative_path = s3_prefix_from_hash(hash=file_hash, suffix=path_file.suffix)
 
         # Remote path in S3 bucket e.g. 's3://bucket-name/sample/data/e2/b0/e2b000ac47b19a999bee5456a6addb88.png'
-        remote_path = f"{bucket_prefix}/{relative_path}"
+        remote_path = f"{s3_uri_prefix}/{relative_path}"
         remote_paths.append(remote_path)
 
     dataset.samples = dataset.samples.with_columns(pl.Series(remote_paths).alias(SampleField.REMOTE_PATH))
 
-    user_logger.info(f"Syncing dataset to S3 bucket '{bucket_prefix}'")
-    files_in_s3 = set(s5cmd_utils.list_bucket(bucket_prefix=bucket_prefix, append_envs=envs))
+    user_logger.info(f"Syncing dataset to S3 bucket '{s3_uri_prefix}'")
+    files_in_s3 = set(s5cmd_utils.list_bucket(bucket_prefix=s3_uri_prefix, append_envs=envs))
 
     # Discover data files (images, videos, etc.) missing in s3
     data_files_missing = dataset.samples.filter(~pl.col(SampleField.REMOTE_PATH).is_in(files_in_s3))
@@ -214,14 +215,14 @@ def sync_dataset_files_to_s3(
         metadata_files_local = []
         metadata_files_s3 = []
         for filename in path_temp.iterdir():
-            metadata_files_s3.append(f"{bucket_prefix}/versions/{dataset.info.version}/{filename.name}")
+            metadata_files_s3.append(f"{s3_uri_prefix}/versions/{dataset.info.version}/{filename.name}")
             metadata_files_local.append(filename.as_posix())
 
         overwrite_metadata_files = files_in_s3.intersection(set(metadata_files_s3))
         will_overwrite_metadata_files = len(overwrite_metadata_files) > 0
 
         n_files_already_in_s3 = len(files_already_in_s3)
-        user_logger.info(f"Sync dataset to {bucket_prefix}")
+        user_logger.info(f"Sync dataset to {s3_uri_prefix}")
         user_logger.info(
             f"- Found that {n_files_already_in_s3} / {len(dataset.samples)} data files already exist. "
             f"Meaning {len(data_files_missing)} data files will be uploaded. \n"
@@ -301,7 +302,7 @@ def sync_dataset_files_to_platform_from_resource_credentials(
 
         sync_dataset_files_to_s3(
             dataset=dataset_variant,
-            bucket_prefix=f"s3://{bucket_name}/{dataset_variant_type.value}",
+            bucket_prefix=f"{bucket_name}/{dataset_variant_type.value}",
             interactive=interactive,
             allow_version_overwrite=allow_version_overwrite,
             envs=envs,
@@ -353,9 +354,20 @@ def sync_files_from_platform(
     subfolder_name: str = "data",
     cfg: Optional[Config] = None,
 ) -> HafniaDataset:
-    """
-    This function is used for
+    """Download data files referenced by ``dataset`` from the Hafnia platform.
 
+    Resolves a local destination under ``path_output_folder / subfolder_name``,
+    fetches read credentials per dataset name, and copies the files via s5cmd.
+    The returned dataset has ``FILE_PATH`` rewritten to the local locations.
+
+    Args:
+        dataset: Dataset whose ``REMOTE_PATH`` column points at platform-managed S3 objects.
+        path_output_folder: Local folder to download into.
+        force_redownload: If ``True``, re-download files that already exist locally.
+        extend_name_by_subfolder: Number of trailing remote path segments to fold
+            into the local filename (useful when remote paths share a basename).
+        subfolder_name: Subfolder under ``path_output_folder`` to write data into.
+        cfg: Optional Hafnia CLI config; defaults to a fresh ``Config()``.
     """
     dataset, download_df = _resolve_local_download_paths(
         dataset=dataset,

--- a/src/hafnia/dataset/operations/dataset_s3_storage.py
+++ b/src/hafnia/dataset/operations/dataset_s3_storage.py
@@ -1,20 +1,22 @@
 import tempfile
 import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
+import boto3
 import polars as pl
+from botocore.exceptions import ClientError
 
 from hafnia.dataset.dataset_helpers import hash_file_xxhash
 from hafnia.dataset.dataset_names import (
     DatasetVariant,
     SampleField,
 )
-from hafnia.dataset.hafnia_dataset import HafniaDataset
+from hafnia.dataset.hafnia_dataset import HafniaDataset, download_meta_dataset_files_from_version
 from hafnia.log import user_logger
 from hafnia.platform import s5cmd_utils
-from hafnia.platform.datasets import get_upload_credentials
-from hafnia.platform.s5cmd_utils import ResourceCredentials
+from hafnia.platform.datasets import get_read_credentials_by_name, get_upload_credentials
+from hafnia.platform.s5cmd_utils import AwsCredentials, ResourceCredentials, fast_copy_files
 from hafnia.utils import progress_bar
 from hafnia_cli.config import Config
 
@@ -67,7 +69,112 @@ def delete_hafnia_dataset_files_from_resource_credentials(
     return True
 
 
-def sync_hafnia_dataset_to_s3(
+def _ensure_s3_bucket_exists(session: boto3.Session, bucket_name: str) -> None:
+    """Create ``bucket_name`` if it does not already exist.
+
+    A successful ``head_bucket`` call (200) is treated as "exists, nothing to
+    do". A 404 triggers creation in the session's region. Any other error
+    (e.g. 403 Forbidden — bucket exists but is owned by someone else) is
+    re-raised so the caller does not silently overwrite or proceed.
+    """
+    s3_client = session.client("s3")
+    try:
+        s3_client.head_bucket(Bucket=bucket_name)
+        return
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code")
+        if error_code not in ("404", "NoSuchBucket"):
+            raise
+
+    region = session.region_name
+    create_kwargs: Dict[str, Any] = {"Bucket": bucket_name}
+    # us-east-1 must NOT include LocationConstraint; every other region must.
+    if region and region != "us-east-1":
+        create_kwargs["CreateBucketConfiguration"] = {"LocationConstraint": region}
+    s3_client.create_bucket(**create_kwargs)
+    user_logger.info(f"Created S3 bucket '{bucket_name}' in region '{region or 'us-east-1'}'.")
+
+
+def download_dataset_from_s3(
+    bucket_prefix: str,
+    path_local: Path,
+    session: boto3.Session,
+    version: Optional[str] = None,
+    force_redownload: bool = False,
+) -> HafniaDataset:
+    """Download a Hafnia dataset from a user-controlled S3 bucket.
+
+    Downloads the metadata files for the requested ``version`` (or latest if
+    ``None``), then syncs the data files referenced by the dataset to
+    ``path_local``. The returned dataset has ``FILE_PATH`` columns rewritten
+    to the local file paths and the annotation files on disk are updated to
+    match.
+
+    Args:
+        bucket_prefix: S3 location without scheme, e.g. ``"my-bucket/sample"``.
+        path_local: Local folder to download into.
+        session: Boto3 session used to obtain credentials.
+        version: Dataset version string (e.g. ``"0.1.0"``) or ``None`` for latest.
+        force_redownload: If ``True``, re-download data files that already
+            exist locally.
+    """
+    resource_credentials = AwsCredentials.from_session(session=session).to_resource_credentials(bucket_prefix)
+
+    download_meta_dataset_files_from_version(
+        resource_credentials=resource_credentials, version=version, path_dataset=path_local
+    )
+
+    dataset = HafniaDataset.from_path(path_local, check_for_images=False)
+    dataset = sync_dataset_files_from_s3(
+        dataset,
+        path_local,
+        aws_credentials=resource_credentials,
+        force_redownload=force_redownload,
+    )
+    dataset.write_annotations(path_folder=path_local)  # Overwrite annotations as files have been re-downloaded
+    return dataset
+
+
+def upload_dataset_to_s3(
+    dataset: HafniaDataset,
+    bucket_prefix: str,
+    session: boto3.Session,
+    allow_version_overwrite: bool = False,
+    create_bucket_if_missing: bool = True,
+    interactive: bool = True,
+) -> None:
+    """Upload a Hafnia dataset to a user-controlled S3 bucket.
+
+    Args:
+        dataset: Dataset to upload.
+        bucket_prefix: S3 location without scheme, e.g. ``"my-bucket"`` or
+            ``"my-bucket/sample"``. The leading segment is treated as the
+            bucket name for the optional create step.
+        session: Boto3 session used to obtain credentials and (optionally)
+            create the bucket.
+        allow_version_overwrite: If ``True``, overwrite metadata files for an
+            existing version in S3. Otherwise the upload aborts when a
+            version collision is detected.
+        create_bucket_if_missing: If ``True`` and the target bucket does not
+            exist, create it in the session's region before uploading.
+        interactive: If ``True``, prompt for confirmation before uploading.
+    """
+    resource_credentials = AwsCredentials.from_session(session=session).to_resource_credentials(bucket_prefix)
+    envs = resource_credentials.aws_credentials()
+
+    if create_bucket_if_missing:
+        _ensure_s3_bucket_exists(session=session, bucket_name=resource_credentials.bucket_name())
+
+    sync_dataset_files_to_s3(
+        dataset=dataset,
+        bucket_prefix=resource_credentials.s3_uri(),
+        interactive=interactive,
+        allow_version_overwrite=allow_version_overwrite,
+        envs=envs,
+    )
+
+
+def sync_dataset_files_to_s3(
     dataset: HafniaDataset,
     bucket_prefix: str,
     allow_version_overwrite: bool = False,
@@ -192,13 +299,155 @@ def sync_dataset_files_to_platform_from_resource_credentials(
             pl.lit(dataset.info.dataset_name).alias(SampleField.DATASET_NAME)
         )
 
-        sync_hafnia_dataset_to_s3(
+        sync_dataset_files_to_s3(
             dataset=dataset_variant,
             bucket_prefix=f"s3://{bucket_name}/{dataset_variant_type.value}",
             interactive=interactive,
             allow_version_overwrite=allow_version_overwrite,
             envs=envs,
         )
+
+
+MISSING_LOCALLY_COLUMN = "MissingLocally"
+
+
+def _resolve_local_download_paths(
+    dataset: HafniaDataset,
+    path_output_folder: Path,
+    extend_name_by_subfolder: int,
+    subfolder_name: str,
+) -> Tuple[HafniaDataset, pl.DataFrame]:
+    if extend_name_by_subfolder < 0:
+        raise ValueError(f"'extend_name_by_subfolder' must be a non-negative integer. Got {extend_name_by_subfolder}.")
+
+    path_data = path_output_folder / subfolder_name
+    path_data.mkdir(parents=True, exist_ok=True)
+
+    update_rows = []
+    for remote_src_path in dataset.samples[SampleField.REMOTE_PATH].unique().to_list():
+        path_parts = remote_src_path.split("/")
+        filename = "_".join(path_parts[-(1 + extend_name_by_subfolder) :])
+        local_path_str = (path_data / filename).absolute().as_posix()
+        update_rows.append(
+            {
+                SampleField.REMOTE_PATH: remote_src_path,
+                SampleField.FILE_PATH: local_path_str,
+                MISSING_LOCALLY_COLUMN: not Path(local_path_str).exists(),
+            }
+        )
+    download_df = pl.DataFrame(update_rows)
+
+    samples = dataset.samples.update(
+        download_df.select([SampleField.REMOTE_PATH, SampleField.FILE_PATH]),
+        on=[SampleField.REMOTE_PATH],
+    )
+    dataset = dataset.update_samples(samples)
+    return dataset, download_df
+
+
+def sync_files_from_platform(
+    dataset: HafniaDataset,
+    path_output_folder: Path,
+    force_redownload: bool = False,
+    extend_name_by_subfolder: int = 0,
+    subfolder_name: str = "data",
+    cfg: Optional[Config] = None,
+) -> HafniaDataset:
+    """
+    This function is used for
+
+    """
+    dataset, download_df = _resolve_local_download_paths(
+        dataset=dataset,
+        path_output_folder=path_output_folder,
+        extend_name_by_subfolder=extend_name_by_subfolder,
+        subfolder_name=subfolder_name,
+    )
+
+    # Extend 'download_df' with dataset name - but keep only unique remote paths to avoid duplicate downloads
+    download_samples = download_df.join(
+        dataset.samples.select([SampleField.REMOTE_PATH, SampleField.DATASET_NAME]),
+        on=SampleField.REMOTE_PATH,
+        how="left",
+    ).unique(subset=SampleField.REMOTE_PATH, keep="first")
+    missing_samples = download_samples.filter(pl.col(MISSING_LOCALLY_COLUMN))
+    existing_samples = download_samples.filter(pl.col(MISSING_LOCALLY_COLUMN) == False)  # noqa: E712
+
+    if not force_redownload and len(missing_samples) == 0:
+        user_logger.info(
+            "All files already exist locally. Skipping download. Set 'force_redownload=True' to re-download."
+        )
+        return dataset
+
+    if force_redownload:
+        missing_samples = download_samples
+    else:
+        if len(existing_samples) > 0:
+            user_logger.info(
+                f"Found {len(existing_samples)}/{len(download_samples)} files already exists. "
+                f"Downloading {len(missing_samples)} files."
+            )
+
+    cfg = cfg or Config()
+    for (dataset_name,), dataset_group in missing_samples.group_by(SampleField.DATASET_NAME):
+        if dataset_name is None:
+            user_logger.warning("Dataset name is missing in the samples. Cannot download files without dataset name.")
+            continue
+        user_logger.info(f"Downloading files for dataset '{dataset_name}'...")
+        remote_src_paths = dataset_group[SampleField.REMOTE_PATH].to_list()
+        local_dst_paths = dataset_group[SampleField.FILE_PATH].to_list()
+        resource_credentials: ResourceCredentials = get_read_credentials_by_name(dataset_name=dataset_name, cfg=cfg)
+        environment_vars = resource_credentials.aws_credentials()
+        fast_copy_files(
+            src_paths=remote_src_paths,
+            dst_paths=local_dst_paths,
+            append_envs=environment_vars,
+            description="Downloading images",
+        )
+    return dataset
+
+
+def sync_dataset_files_from_s3(
+    dataset: HafniaDataset,
+    path_output_folder: Path,
+    aws_credentials: AwsCredentials,
+    force_redownload: bool = False,
+    extend_name_by_subfolder: int = 0,
+    subfolder_name: str = "data",
+) -> HafniaDataset:
+    dataset, download_df = _resolve_local_download_paths(
+        dataset=dataset,
+        path_output_folder=path_output_folder,
+        extend_name_by_subfolder=extend_name_by_subfolder,
+        subfolder_name=subfolder_name,
+    )
+
+    if force_redownload:
+        download_samples = download_df
+    else:
+        download_samples = download_df.filter(pl.col(MISSING_LOCALLY_COLUMN))
+        skip_files = len(download_df) - len(download_samples)
+        if skip_files > 0:
+            user_logger.info(
+                f"Found {skip_files}/{len(download_df)} files already exists. "
+                f"Downloading {len(download_samples)} files."
+            )
+
+    if len(download_samples) == 0:
+        user_logger.info(
+            "All files already exist locally. Skipping download. Set 'force_redownload=True' to re-download."
+        )
+        return dataset
+
+    environment_vars = aws_credentials.aws_credentials()
+    fast_copy_files(
+        src_paths=download_samples[SampleField.REMOTE_PATH].to_list(),
+        dst_paths=download_samples[SampleField.FILE_PATH].to_list(),
+        append_envs=environment_vars,
+        description="Downloading images",
+    )
+
+    return dataset
 
 
 def s3_prefix_from_hash(hash: str, suffix: str) -> str:

--- a/src/hafnia/dataset/operations/dataset_transformations.py
+++ b/src/hafnia/dataset/operations/dataset_transformations.py
@@ -469,6 +469,43 @@ def select_samples_by_class_name(
     return dataset_updated
 
 
+def drop_samples_by_class_name(
+    dataset: "HafniaDataset",
+    name: Union[List[str], str],
+    task_name: Optional[str] = None,
+    primitive: Optional[Type[Primitive]] = None,
+    drop_classes_from_task_info: bool = True,
+) -> "HafniaDataset":
+    from hafnia.dataset.hafnia_dataset import HafniaDataset
+
+    task, class_names = _validate_inputs_select_samples_by_class_name(
+        dataset=dataset,
+        name=name,
+        task_name=task_name,
+        primitive=primitive,
+    )
+
+    contains_dropped_class = (
+        pl.col(task.primitive.column_name())
+        .list.eval(
+            pl.element().struct.field(PrimitiveField.CLASS_NAME).is_in(class_names)
+            & (pl.element().struct.field(PrimitiveField.TASK_NAME) == task.name)
+        )
+        .list.any()
+    )
+    samples = dataset.samples.filter(~contains_dropped_class)
+
+    if not drop_classes_from_task_info:
+        return dataset.update_samples(samples)
+
+    new_classes = [c for c in (task.classes or []) if c.name not in class_names]
+    new_task = TaskInfo(primitive=task.primitive, name=task.name, classes=new_classes)
+    dataset_info = dataset.info.replace_task(old_task=task, new_task=new_task)
+    if new_classes:
+        samples = update_class_indices(samples, new_task)
+    return HafniaDataset(info=dataset_info, samples=samples)
+
+
 def _validate_inputs_select_samples_by_class_name(
     dataset: "HafniaDataset",
     name: Union[List[str], str],

--- a/src/hafnia/dataset/operations/flattening_attributes.py
+++ b/src/hafnia/dataset/operations/flattening_attributes.py
@@ -68,6 +68,10 @@ def _expand_class_info(
         return [class_info]
 
     other_attrs = [a for a in attrs if a.name != attr_name]
+    base_class = ClassInfo(
+        name=class_info.name,
+        attributes=other_attrs if other_attrs else None,
+    )
     result: List[ClassInfo] = []
     for sub_class in matching_attr.classes or []:
         for expanded in _expand_class_info(sub_class, remaining, separator):
@@ -78,7 +82,7 @@ def _expand_class_info(
                     attributes=merged_attrs if merged_attrs else None,
                 )
             )
-    return [class_info] + result
+    return [base_class] + result
 
 
 def flatten_class_names(

--- a/tests/integration/test_recipe_download_logic.py
+++ b/tests/integration/test_recipe_download_logic.py
@@ -5,21 +5,31 @@ import pytest
 from hafnia.dataset.dataset_names import SampleField
 from hafnia.dataset.dataset_recipe.dataset_recipe import DatasetRecipe
 from hafnia.dataset.hafnia_dataset import HafniaDataset
+from hafnia.dataset.operations.dataset_s3_storage import sync_files_from_platform
 from hafnia.utils import is_hafnia_configured
 from tests.helper_testing_datasets import DATASET_SPEC_MNIST
 
 
 def test_recipe_download_files_with_write(tmp_path):
     """
-    Verifies the logic used in the "fetching data" step. The main idea is to save resources by
-    only downloading files that are used in the final recipe (after merging and filtering) and also
-    avoids  hashing and coping of files by downloading files by saving only annotations to the same path.
+    Verifies the logic used in the "fetching data" step. The naive approach would be to
+    first build the recipe and then write the dataset to a local path:
 
+    ```python
+    dataset: HafniaDataset = recipe.build()  # This would download all files to a temp location
+    dataset.write(path_write)  # This would copy and hash all files to path.
+    ```
+    Above approach would both download, copy and hash all files which requires storage and is time consuming.
 
-    # Code snippet to be used in "fetching data" step in the recipe build logic:
+    Instead we can do the following:
+    ```python
     dataset: HafniaDataset = recipe.build(download_files=False)
-    dataset = dataset.download_files(path_write)
+    dataset = sync_files_from_platform(dataset, path_write)
     dataset.write_annotations(path_write)
+    ```
+    This approach approach has multiple performance advantages
+    1) We download only files after (potentially) filtering done in the recipe.
+    2) We avoid the write() operation that would both copy and hash all images/video files.
     """
     if not is_hafnia_configured():
         pytest.skip("Hafnia platform not configured. Skipping recipe download logic test.")
@@ -32,9 +42,7 @@ def test_recipe_download_files_with_write(tmp_path):
     path_write = tmp_path / "write"
 
     dataset: HafniaDataset = recipe.build(download_files=False)  # Images/videos are not downloaded yet
-    dataset = dataset.download_files(
-        path_write
-    )  # Now images are download to a single folder (avoid both a copy and downloading files that we don't need)
+    dataset = sync_files_from_platform(dataset, path_write)
 
     # All file paths should now exist locally
     file_paths = dataset.samples[SampleField.FILE_PATH].to_list()

--- a/tests/unit/dataset/dataset_recipe/test_recipe_transformations.py
+++ b/tests/unit/dataset/dataset_recipe/test_recipe_transformations.py
@@ -11,6 +11,7 @@ from hafnia.dataset.dataset_recipe.dataset_recipe import DatasetRecipe, FromName
 from hafnia.dataset.dataset_recipe.recipe_transforms import (
     ClassMapper,
     DefineSampleSetBySize,
+    DropSamplesByClassName,
     RenameTask,
     SelectSamples,
     SelectSamplesByClassName,
@@ -80,6 +81,13 @@ def get_test_cases() -> list[TestCaseRecipeTransform]:
             recipe_transform=SelectSamplesByClassName(name=["Person"], task_name=None, primitive=None),
             as_python_code="select_samples_by_class_name(name=['Person'], task_name=None, primitive=None)",
             short_name="SelectSamplesByClassName",
+        ),
+        TestCaseRecipeTransform(
+            recipe_transform=DropSamplesByClassName(
+                name=["Person"], task_name=None, primitive=None, drop_classes_from_task_info=False
+            ),
+            as_python_code="drop_samples_by_class_name(name=['Person'], task_name=None, primitive=None, drop_classes_from_task_info=False)",  # noqa: E501
+            short_name="DropSamplesByClassName",
         ),
     ]
 

--- a/tests/unit/dataset/format_conversions/test_format_encord.py
+++ b/tests/unit/dataset/format_conversions/test_format_encord.py
@@ -208,6 +208,18 @@ def test_flattening_specification(encord_dataset_tiny: HafniaDataset):
     class_name_counts = dataset_flat.calculate_class_counts()
     class_names = [cn["Class Name"] for cn in class_name_counts]
 
+    # Test to verify that "Vehicle Color" attributes is removed after flattening
+    bb_task = dataset_flat.info.get_task_by_primitive(primitives.Bbox)
+    class_vehicle_base = bb_task.get_class_by_name("Vehicle")
+    vehicle_attributes = class_vehicle_base.attributes or []  # type: ignore
+    has_color_attribute = any(attr.name == "Vehicle Color" for attr in vehicle_attributes)
+    assert not has_color_attribute, "Color attribute should be flattened into class name and removed from attributes"
+
+    class_vehicle_gray = bb_task.get_class_by_name("Vehicle.Gray")
+    vehicle_gray_attributes = class_vehicle_gray.attributes or []  # type: ignore
+    has_color_attribute = any(attr.name == "Vehicle Color" for attr in vehicle_gray_attributes)
+    assert not has_color_attribute, "Color attribute should be flattened into class name and removed from attributes"
+
     assert len([cn for cn in class_names if cn == "Vehicle"]) == 1, "Expected base class after flattening"
     assert len([cn for cn in class_names if cn == "Vehicle.Gray"]) == 1, "Expected base class after flattening"
     assert len([cn for cn in class_names if cn == "Sunrise/Sunset"]) == 1, "Expected base class after flattening"

--- a/tests/unit/dataset/operations/test_dataset_transformations.py
+++ b/tests/unit/dataset/operations/test_dataset_transformations.py
@@ -254,6 +254,37 @@ def test_select_samples_by_class_name():
         dataset_updated = dataset.select_samples_by_class_name(name="Vehicle.Car", task_name="Weather")
 
 
+def test_drop_samples_by_class_name():
+    dataset_name = "micro-tiny-dataset"
+    path_dataset = get_path_micro_hafnia_dataset(dataset_name=dataset_name, force_update=False)
+    dataset = HafniaDataset.from_path(path_dataset)
+
+    selected = dataset.select_samples_by_class_name(name="Vehicle.Car")
+    dropped = dataset.drop_samples_by_class_name(name="Vehicle.Car")
+    assert len(dropped) == len(dataset) - len(selected), (
+        "Expected drop and select to be complementary on the same class name"
+    )
+
+    bbox_task = dropped.info.get_task_by_primitive(Bbox)
+    bboxes = dropped.samples[bbox_task.primitive.column_name()].explode().struct.unnest()
+    bbox_names = bboxes.filter(bboxes[PrimitiveField.TASK_NAME] == bbox_task.name)[PrimitiveField.CLASS_NAME]
+    assert "Vehicle.Car" not in set(bbox_names), "Dropped class should not appear in any remaining annotation"
+
+    # drop_classes_from_task_info=True removes the class from TaskInfo and re-indexes
+    dropped_with_info = dataset.drop_samples_by_class_name(name="Vehicle.Car", drop_classes_from_task_info=True)
+    new_bbox_task = dropped_with_info.info.get_task_by_primitive(Bbox)
+    assert "Vehicle.Car" not in (new_bbox_task.get_class_names() or [])
+    new_class_names = new_bbox_task.get_class_names() or []
+    new_bboxes = dropped_with_info.samples[new_bbox_task.primitive.column_name()].explode().struct.unnest()
+    new_bboxes = new_bboxes.filter(new_bboxes[PrimitiveField.TASK_NAME] == new_bbox_task.name)
+    for cls_name, cls_idx in zip(new_bboxes[PrimitiveField.CLASS_NAME], new_bboxes[PrimitiveField.CLASS_IDX]):
+        assert new_class_names.index(cls_name) == cls_idx, "Class indices should match the new task class ordering"
+
+    # Wrong class name (not found in any task)
+    with pytest.raises(ValueError, match="The specified names"):
+        dataset.drop_samples_by_class_name(name="NonExistingClass", primitive=Bbox)
+
+
 def test_get_task_info_from_task_name_and_primitive():
     task_class = TaskInfo.from_class_names(primitive="Classification", class_names=["cat", "dog"])
     task_bbox = TaskInfo.from_class_names(primitive="Bbox", class_names=["car", "bus"])

--- a/uv.lock
+++ b/uv.lock
@@ -1389,14 +1389,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The following changes have been added to support the generation of the new ECCV dataset

Adds user-controlled S3 upload/download (`HafniaDataset.from_s3` / `.to_s3`), a `drop_samples_by_class_name` operation, fixes attribute-flattening behavior in encord conversions, and refactors `dataset_s3_storage.py` (renames `sync_hafnia_dataset_to_s3` --> `sync_dataset_files_to_s3`, extracts `download_files` method into a top-level `sync_files_from_platform`, `adds _resolve_local_download_paths` helper).