### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ hafnia runc        build | build-local | launch-local            # Build and run
 Run `hafnia <group> --help` (and `hafnia <group> <subcommand> --help`) to see the full set of
 options for any command.
 
+## Detailed Documentation
+
+For more information, go to our [documentation page](https://hafnia.readme.io/docs/welcome-to-hafnia)
+or use the topic guides below. The rest of this README links into them from each relevant section.
+
+- [CLI](docs/cli.md) — Detailed guide for the Hafnia command-line interface.
+- [Hafnia Dataset Format](docs/dataset.md) — The `HafniaDataset` in-memory format, annotation primitives and operations.
+- [Dataset Recipes](docs/dataset_recipe.md) — Composing reproducible datasets with `DatasetRecipe`.
+- [Custom Datasets](docs/custom_dataset.md) — Building a `HafniaDataset` from your own images and annotations.
+- [Benchmarking](docs/benchmark.md) — Running models against a dataset and computing metrics.
+- [Release lifecycle](docs/release.md) — Details about the package release lifecycle.
+
 ## Trainer Packages: Bring Your Own Training Code
 
 When the public trainer packages are not enough — for example because you want a different model
@@ -198,7 +210,8 @@ Available datasets (and their sample variants) are listed in the
 [data library](https://hafnia.milestonesys.com/training-aas/datasets) including metadata and a
 description for each dataset.
 
-For a deeper walkthrough of `HafniaDataset`, see
+For a deeper walkthrough of `HafniaDataset`, see the
+[Hafnia Dataset Format](docs/dataset.md) guide and the runnable
 [examples/example_hafnia_dataset.py](examples/example_hafnia_dataset.py).
 
 ### Composing datasets with `DatasetRecipe`
@@ -221,17 +234,22 @@ recipe.as_platform_recipe(recipe_name="example-mnist-recipe", overwrite=True)
 
 Recipes can also be managed on the platform via the CLI: `hafnia recipe ls | create | rm`.
 
-See [examples/example_dataset_recipe.py](examples/example_dataset_recipe.py) for a full walkthrough
-including merging datasets and class-level operations.
+For a deeper walkthrough — including the recipe lifecycle, supported operations, merging and
+platform upload — see the [Dataset Recipes](docs/dataset_recipe.md) guide and the runnable
+[examples/example_dataset_recipe.py](examples/example_dataset_recipe.py).
 
 ### Bringing your own data: custom `HafniaDataset`
 
 If you have data that is not yet on the Hafnia platform, you can construct a `HafniaDataset`
-directly from images and annotations. See
-[examples/example_custom_dataset.py](examples/example_custom_dataset.py) for an end-to-end example
-that builds a `HafniaDataset` from a YOLO-formatted directory using `Sample`, `Bbox` and
-`DatasetInfo`. Built-in importers such as `HafniaDataset.from_yolo_format` are also available for
+directly from images and annotations using `Sample`, the annotation primitives (`Bbox`, `Bitmask`,
+`Polygon`, `Classification`) and `DatasetInfo`. Built-in importers such as
+`HafniaDataset.from_yolo_format` and `HafniaDataset.from_coco_format` are also available for
 common formats.
+
+For a walkthrough of the building blocks and gotchas, see the
+[Custom Datasets](docs/custom_dataset.md) guide and the runnable
+[examples/example_custom_dataset.py](examples/example_custom_dataset.py), which builds a
+`HafniaDataset` from a YOLO-formatted directory end-to-end.
 
 ### Torch dataloader
 
@@ -299,17 +317,11 @@ to use it in a real training script.
 ### Benchmarking models on a `HafniaDataset`
 
 The benchmark utilities run an `InferenceModel` over a dataset, store the predictions as a new
-dataset and compute metrics (e.g. object-detection mAP) against the ground truth. See
-[examples/example_benchmark.py](examples/example_benchmark.py) for a runnable example wrapping a
-torchvision SSDLite detector.
-
-## Detailed Documentation
-
-For more information, go to our [documentation page](https://hafnia.readme.io/docs/welcome-to-hafnia)
-or in below markdown pages.
-
-- [CLI](docs/cli.md) - Detailed guide for the Hafnia command-line interface
-- [Release lifecycle](docs/release.md) - Details about package release lifecycle.
+task on a copy of the dataset and compute metrics (e.g. object-detection mAP) against the ground
+truth. For the `InferenceModel` interface, available metrics and the full flow, see the
+[Benchmarking](docs/benchmark.md) guide and the runnable
+[examples/example_benchmark.py](examples/example_benchmark.py), which wraps a torchvision
+SSDLite detector.
 
 ## Development
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,97 @@
+# Benchmarking Models on a `HafniaDataset`
+
+The `hafnia.dataset.benchmark` module runs a model over a `HafniaDataset`,
+stores predictions as a new task on a copy of the dataset, and computes
+metrics against the ground truth. The whole flow uses regular `HafniaDataset`
+objects, so predictions, ground truth and metrics live side-by-side and can
+be inspected, visualized or exported like any other dataset.
+
+## The `InferenceModel` interface
+
+Any model that implements `InferenceModel` can be benchmarked. The interface
+has two methods:
+
+```python
+from hafnia.dataset.benchmark.inference_model import InferenceModel, ImageType
+from hafnia.dataset.hafnia_dataset_types import ModelInfo, TaskInfo
+from hafnia.dataset.primitives import Bbox, Primitive
+
+class MyModel(InferenceModel):
+    def get_model_info(self) -> ModelInfo:
+        return ModelInfo(
+            name="MyDetector",
+            tasks=[TaskInfo.from_class_names(primitive=Bbox, class_names=[...])],
+        )
+
+    def predict(self, images, sample_dict=None) -> list[Primitive]:
+        # Return primitives in hafnia format (normalized coords, class_name set,
+        # ground_truth=False, confidence=<float>).
+        ...
+```
+
+Predictions must be returned as **hafnia primitives** with `ground_truth=False`
+and a `confidence` value, so they can be stored alongside the ground truth in
+the same dataset.
+
+## Running inference and computing metrics
+
+The simplest path is `benchmark.run_benchmark`, which runs inference and
+computes the appropriate metrics in one call:
+
+```python
+from hafnia.dataset.benchmark import benchmark
+from hafnia.dataset.hafnia_dataset import HafniaDataset
+
+dataset = HafniaDataset.from_name("coco-2017", version="1.0.0").select_samples(n_samples=10)
+model   = MyModel()
+
+metrics, dataset_predictions = benchmark.run_benchmark(dataset=dataset, model=model)
+```
+
+If you want to inspect the prediction dataset before scoring, split the call:
+
+```python
+dataset_predictions = benchmark.run_inference_on_dataset(dataset=dataset, model=model)
+
+# Compute a specific metric directly on the dataset
+map_metrics = dataset_predictions.calculate_mean_average_precision(
+    task_name_ground_truth="object_detection",
+    task_name_predictions="object_detection/predictions",
+)
+map_metrics.print_report()
+
+# Or auto-derive all relevant metrics from the dataset's tasks
+metrics = benchmark.metric_calculations(prediction_dataset=dataset_predictions)
+```
+
+Predictions are added as a new task with the suffix
+`/predictions` (controlled by `task_name_prediction_postfix`). The ground
+truth task is untouched, which makes side-by-side visualization easy.
+
+## Visualizing predictions
+
+Because predictions are stored as primitives on `Sample`, you can filter and
+draw them like any annotation:
+
+```python
+from hafnia.dataset.hafnia_dataset_types import Sample
+from PIL import Image
+
+sample = Sample(**dataset_predictions[0])
+sample.bboxes = [b for b in sample.bboxes if not b.ground_truth and b.confidence >= 0.2]
+Image.fromarray(sample.draw_annotations()).save("predictions.png")
+```
+
+## Metrics
+
+The metric layer auto-derives applicable metrics from the dataset's tasks
+(for example, mAP for object detection). Implement
+`MetricsCalculator.__call__(dataset) -> dict[str, float]` and pass it via
+`metric_calculators=` to plug in custom metrics. See
+[src/hafnia/dataset/benchmark/metrics_calculator.py](../src/hafnia/dataset/benchmark/metrics_calculator.py)
+for the built-in calculators and the auto-derivation logic.
+
+## See also
+
+- [examples/example_benchmark.py](../examples/example_benchmark.py) — runnable walkthrough wrapping torchvision's SSDLite as an `InferenceModel` and benchmarking it on COCO.
+- [docs/dataset.md](dataset.md) — the `HafniaDataset` format used for both inputs and outputs of benchmarking.

--- a/docs/custom_dataset.md
+++ b/docs/custom_dataset.md
@@ -1,0 +1,117 @@
+# Building a Custom `HafniaDataset`
+
+When your data is not already on the Hafnia platform — for example a private
+dataset on disk, or annotations in a non-standard format — you can construct
+a `HafniaDataset` directly from images and annotation primitives. The result
+is a regular `HafniaDataset` that supports all the usual operations,
+exporters and (optionally) upload to the platform.
+
+Before writing custom code, check whether a built-in importer already covers
+your format:
+
+```python
+HafniaDataset.from_yolo_format(path)
+HafniaDataset.from_coco_format(path)
+```
+
+See [src/hafnia/dataset/format_conversions/](../src/hafnia/dataset/format_conversions/)
+for the full list. The custom path described below is the right tool only
+when no importer fits.
+
+## The three building blocks
+
+To build a dataset by hand you need three things:
+
+1. **Annotation primitives per image** — instances of `Bbox`, `Bitmask`,
+   `Polygon` or `Classification`. Bounding-box coordinates are normalized
+   to `[0, 1]` and use `top_left_x`, `top_left_y`, `width`, `height`.
+2. **A `Sample` per image** — wraps the file path, image dimensions, split
+   name and the list of primitives.
+3. **A `DatasetInfo`** — declares the dataset name, version and the
+   `TaskInfo`s (primitive + class names).
+
+`HafniaDataset.from_samples_list(samples_list, info=...)` then turns these
+into a dataset.
+
+## End-to-end example
+
+```python
+from pathlib import Path
+from PIL import Image
+from hafnia.dataset.hafnia_dataset import HafniaDataset
+from hafnia.dataset.hafnia_dataset_types import DatasetInfo, Sample, TaskInfo
+from hafnia.dataset.primitives.bbox import Bbox
+
+class_names = ["person", "car", "bicycle"]
+samples = []
+for path_image in Path("data/images").glob("*.jpg"):
+    image = Image.open(path_image)
+    width, height = image.size
+
+    # Read your annotations however you like; build hafnia Bbox primitives.
+    bboxes = [
+        Bbox(
+            top_left_x=cx - bw / 2,
+            top_left_y=cy - bh / 2,
+            width=bw,
+            height=bh,
+            class_idx=class_idx,
+            class_name=class_names[class_idx],
+        )
+        for class_idx, cx, cy, bw, bh in read_yolo_txt(path_image.with_suffix(".txt"))
+    ]
+    samples.append(Sample(
+        file_path=str(path_image),
+        height=height,
+        width=width,
+        split="train",
+        bboxes=bboxes,
+    ))
+
+info = DatasetInfo(
+    dataset_name="my-custom-dataset",
+    version="0.0.1",
+    tasks=[TaskInfo(primitive=Bbox, class_names=class_names)],
+)
+dataset = HafniaDataset.from_samples_list(samples_list=samples, info=info)
+```
+
+Once built, the dataset behaves like any other:
+
+```python
+dataset.print_stats()
+sample = Sample(**dataset[0])
+Image.fromarray(sample.draw_annotations()).save("preview.png")
+dataset.write(".data/datasets/my-custom-dataset")
+```
+
+## Tips and gotchas
+
+- **Image dimensions are required.** Read them once per image and pass them
+  to `Sample` — primitive coordinates are normalized against them.
+- **Each `Sample.split` value matters.** Use `"train"`, `"val"`, `"test"` (or
+  `SplitName.*`) consistently so `create_split_dataset(...)` works later.
+- **`class_idx` should agree with `class_name`.** The `TaskInfo.class_names`
+  order defines the index space; keep them in sync to avoid surprises in
+  metrics and exports.
+- **Predictions vs ground truth.** Set `ground_truth=False` and add
+  `confidence=...` on a primitive to store predictions instead of labels.
+
+## Uploading to the platform (optional)
+
+If your custom dataset should become a named Hafnia dataset, use
+`HafniaDataset.upload_to_platform`:
+
+```python
+dataset.upload_to_platform(
+    interactive=False,
+    allow_version_overwrite=True,
+    gallery_samples=...,   # optional preview samples
+)
+```
+
+## See also
+
+- [examples/example_custom_dataset.py](../examples/example_custom_dataset.py) — runnable walkthrough that builds a dataset from a YOLO-formatted directory.
+- [docs/dataset.md](dataset.md) — the resulting `HafniaDataset` format and operations.
+- [docs/dataset_recipe.md](dataset_recipe.md) — composing your custom dataset with other sources via recipes.

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -1,0 +1,114 @@
+# The Hafnia Dataset Format
+
+`HafniaDataset` is the in-memory representation of a computer-vision dataset
+used throughout the Hafnia SDK. It is the same object whether you are working
+with a small **sample dataset** locally or with a **full dataset** under
+Training-aaS — a training script written against `HafniaDataset` does not
+change between the two environments.
+
+## What a dataset contains
+
+A `HafniaDataset` is a pair of two fields:
+
+- **`dataset.info`** — a `DatasetInfo` describing the dataset and its tasks.
+  Each `TaskInfo` declares a primitive (`Bbox`, `Bitmask`, `Polygon`,
+  `Classification`, ...) and the list of `ClassInfo` entries that define the
+  label space for that task.
+- **`dataset.samples`** — a [Polars](https://pola.rs/) `DataFrame` where each
+  row is one image (or video frame). Primitive columns (`classifications`,
+  `bboxes`, `bitmasks`, `polygons`) are stored as `List[Struct]` and mirror
+  the fields of the corresponding `Sample` Pydantic model.
+
+A row in `dataset.samples` unpacks into a `Sample` object that carries the
+image path, dimensions, split, tags, optional camera/position/orientation
+metadata, and the per-sample annotation primitives.
+
+## Loading and writing
+
+```python
+from hafnia.dataset.hafnia_dataset import HafniaDataset
+
+# Load by name — sample dataset locally, full dataset under Training-aaS
+dataset = HafniaDataset.from_name("midwest-vehicle-detection", version="1.0.0")
+
+# Or load from disk
+dataset = HafniaDataset.from_path(".data/datasets/midwest-vehicle-detection")
+
+# Persist to disk
+dataset.write(".data/tmp/hafnia_dataset")
+```
+
+`from_name` downloads the dataset to `.data/datasets/` on first call and
+caches it for subsequent calls.
+
+## Iterating samples
+
+```python
+from hafnia.dataset.hafnia_dataset_types import Sample
+
+for sample_dict in dataset:
+    sample = Sample(**sample_dict)   # validate + IDE/mypy support
+    image = sample.read_image()      # np.ndarray
+    for bbox in sample.bboxes or []:
+        print(bbox.class_name, bbox.top_left_x, bbox.top_left_y)
+    break
+```
+
+`Sample` also exposes `draw_annotations()` for quick visualization.
+
+## Common operations
+
+`HafniaDataset` supports chainable operations that return a new dataset:
+
+```python
+dataset_train = dataset.create_split_dataset("train")
+small        = dataset.select_samples(n_samples=10, seed=42)
+shuffled     = dataset.shuffle(seed=42)
+splits       = dataset.splits_by_ratios({"train": 0.8, "val": 0.1, "test": 0.1})
+only_ones    = dataset.select_samples_by_class_name(name="1 - one", primitive="Classification")
+remapped     = dataset.class_mapper(class_mapping={"car": "Vehicle", "person": "Person"})
+merged       = HafniaDataset.from_merge(dataset0=a, dataset1=b)
+```
+
+For statistics, see `dataset.print_stats()`, `dataset.print_class_distribution()`,
+`dataset.calculate_class_counts()` and friends. For anything custom, work
+directly on `dataset.samples` with native Polars expressions.
+
+## Annotation primitives
+
+All annotations inherit from a common `Primitive` base and live in
+[src/hafnia/dataset/primitives/](../src/hafnia/dataset/primitives/):
+
+| Primitive        | Column            | Use                                    |
+| ---------------- | ----------------- | -------------------------------------- |
+| `Classification` | `classifications` | Image- or sample-level labels          |
+| `Bbox`           | `bboxes`          | 2D bounding boxes (normalized coords)  |
+| `Polygon`        | `polygons`        | Polygonal segmentations                |
+| `Bitmask`        | `bitmasks`        | Pixel masks                            |
+
+Each primitive carries `class_name`, `class_idx`, and a `ground_truth` flag.
+Set `ground_truth=False` and add a `confidence` value to store predictions
+alongside ground truth in the same dataset.
+
+## Importers and exporters
+
+Built-in converters under
+[src/hafnia/dataset/format_conversions/](../src/hafnia/dataset/format_conversions/)
+allow round-tripping with common formats:
+
+```python
+dataset.to_yolo_format(path_output=".data/tmp/yolo_dataset")
+HafniaDataset.from_yolo_format(".data/tmp/yolo_dataset")
+
+dataset.to_coco_format(path_output=".data/tmp/coco_dataset")
+HafniaDataset.from_coco_format(".data/tmp/coco_dataset")
+```
+
+To bring data that is not yet on the platform into the Hafnia format, build
+samples directly from `Sample`, `Bbox`, `DatasetInfo`, etc. See
+[examples/example_custom_dataset.py](../examples/example_custom_dataset.py).
+
+## See also
+
+- [examples/example_hafnia_dataset.py](../examples/example_hafnia_dataset.py) — runnable walkthrough.
+- [docs/dataset_recipe.md](dataset_recipe.md) — composing reproducible datasets from recipes.

--- a/docs/dataset_recipe.md
+++ b/docs/dataset_recipe.md
@@ -1,0 +1,148 @@
+# Dataset Recipes
+
+A `DatasetRecipe` is a serializable **specification** of a dataset: which
+sources to start from and which operations to apply on top of them. A recipe
+is *not* a materialized dataset — call `.build()` to turn it into a
+[`HafniaDataset`](dataset.md).
+
+## Why recipes?
+
+`HafniaDataset` is great for interactive exploration: every operation runs
+immediately on the data. But that makes it less convenient when you want to:
+
+- **Reproduce** the exact same dataset locally and inside Training-aaS.
+- **Share** a dataset definition with teammates as a JSON file.
+- **Combine** multiple datasets (with class remapping, filtering, splits)
+  into one training source.
+- **Re-execute** the same composition against the full dataset on the
+  platform after validating it against the sample dataset locally.
+
+Recipes capture all of that as a small, declarative object that travels
+freely between environments.
+
+## The recipe lifecycle
+
+1. **Define** the recipe with the same chainable interface as `HafniaDataset`.
+2. **Build** it locally to verify it produces the dataset you expected.
+3. **Save** it as JSON, or **upload** it to the platform.
+4. **Reuse** the recipe in a Training-aaS experiment — where it builds against
+   the full dataset rather than the sample.
+
+```python
+from hafnia.dataset.dataset_recipe.dataset_recipe import DatasetRecipe
+
+recipe  = DatasetRecipe.from_name("mnist", version="1.0.0").shuffle().select_samples(n_samples=20)
+dataset = recipe.build()   # materialize as a HafniaDataset
+```
+
+The recipe and the equivalent eager call
+
+```python
+HafniaDataset.from_name("mnist", version="1.0.0").shuffle().select_samples(n_samples=20)
+```
+
+produce the same dataset; the recipe just defers execution.
+
+## Sources
+
+Recipes can start from several kinds of sources:
+
+```python
+DatasetRecipe.from_name("mnist", version="1.0.0")            # named platform dataset
+DatasetRecipe.from_name_public_dataset("mnist", n_samples=100) # bundled public dataset (no login)
+DatasetRecipe.from_recipe_name("person-vehicle-detection")    # platform-registered recipe
+```
+
+## Operations
+
+Recipes mirror the `HafniaDataset` transformation surface, so anything you
+verified eagerly translates 1:1 into the recipe:
+
+```python
+recipe = (
+    DatasetRecipe.from_name("coco-2017", version="1.0.0")
+    .class_mapper(class_mapping={"car": "Vehicle", "person": "Person"},
+                  method="remove_undefined", task_name="object_detection")
+    .select_samples_by_class_name(name=["Person", "Vehicle"], task_name="object_detection")
+    .shuffle(seed=42)
+    .splits_by_ratios({"train": 0.8, "val": 0.1, "test": 0.1})
+)
+```
+
+Supported operations include `shuffle`, `select_samples`,
+`select_samples_by_class_name`, `drop_samples_by_class_name`, `class_mapper`,
+`rename_task`, `splits_by_ratios`, and `split_into_multiple_splits`.
+
+## Merging datasets
+
+Multiple recipes can be combined into one — recipes can be nested arbitrarily.
+
+```python
+merged = DatasetRecipe.from_merger(
+    recipes=[
+        DatasetRecipe.from_name("mnist", version="1.0.0"),
+        DatasetRecipe.from_name("mnist", version="1.0.0").select_samples(n_samples=20),
+        DatasetRecipe.from_path(Path(".data/datasets/mnist"))
+                     .splits_by_ratios({"train": 0.8, "val": 0.1, "test": 0.1}),
+    ]
+)
+dataset = merged.build()
+```
+
+`DatasetRecipe.from_merge(recipe0, recipe1)` is the two-recipe shortcut.
+
+## Saving, loading, inspecting
+
+A recipe is a plain JSON payload:
+
+```python
+recipe.as_json_file(Path(".data/dataset_recipes/example.json"))
+again = DatasetRecipe.from_json_file(Path(".data/dataset_recipes/example.json"))
+assert again == recipe
+
+print(recipe.as_json_str())     # JSON string
+print(recipe.as_python_code())  # equivalent Python code
+print(recipe.as_short_name())   # short identifier for logs/paths
+```
+
+## Uploading to Training-aaS
+
+Once you are happy with a recipe locally, upload it to the platform so it
+can be used in experiments:
+
+```python
+recipe.as_platform_recipe(recipe_name="example-mnist-recipe", overwrite=True)
+
+# Later, anywhere in your org:
+recipe = DatasetRecipe.from_recipe_name("example-mnist-recipe")
+```
+
+From the CLI, manage platform recipes with:
+
+```bash
+hafnia recipe ls
+hafnia recipe create <path-to-recipe.json>
+hafnia recipe rm    <recipe-name>
+```
+
+And launch an experiment using a recipe:
+
+```bash
+hafnia experiment create --recipe example-mnist-recipe --trainer-path ../trainer-classification
+```
+
+## Recommended workflow
+
+1. Explore the involved datasets eagerly with `HafniaDataset` (use
+   `print_basic_stats()`, `get_task_by_primitive(...).get_class_names()`, ...).
+2. Validate transformations (class remapping, merging, filtering) on the
+   sample datasets, still using `HafniaDataset`.
+3. Translate the validated operations into a single `DatasetRecipe` and
+   `.build()` it on the sample datasets to confirm parity.
+4. Upload the recipe to the platform and reference it from an experiment to
+   train on the full dataset.
+
+## See also
+
+- [docs/dataset.md](dataset.md) — the `HafniaDataset` format that recipes build into.
+- [examples/example_dataset_recipe.py](../examples/example_dataset_recipe.py) — runnable walkthrough including a Person+Vehicle merge across COCO and Midwest.


### PR DESCRIPTION
Adding documentation pages for: 

- [Hafnia Dataset Format](docs/dataset.md) — The `HafniaDataset` in-memory format, annotation primitives and operations.
- [Dataset Recipes](docs/dataset_recipe.md) — Composing reproducible datasets with `DatasetRecipe`.
- [Custom Datasets](docs/custom_dataset.md) — Building a `HafniaDataset` from your own images and annotations.
- [Benchmarking](docs/benchmark.md) — Running models against a dataset and computing metrics.