### PR TITLE
Use first environement instead of 'Free Tier'

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ To demonstrate the concept of Training-aaS, we will first show how to launch mod
 
 1. **Configure Training**  
    - **Training command:** `python scripts/train.py`
-   - **Configuration:** Select "Free Tier" or "Professional" based on your needs
+   - **Configuration:** Select "Lite", "Pro" or "Scale" based on your needs
 
 1. **Launch & Monitor**  
    Click "Create Experiment" and monitor progress in the dashboard
 
 That's it! You have successfully launched an object detection model training experiment using the Hafnia Training-aaS platform.
 
-For default training parameters, the trainer package converges in approximately 4 hours on the `midwest-vehicle-detection` dataset using the "Free Tier" configuration.
+For default training parameters, the trainer package converges in approximately 4 hours on the `midwest-vehicle-detection` dataset using the "Lite" configuration.
 
 ## Installation and Configuration
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -110,7 +110,7 @@ hafnia experiment create [OPTIONS]
 |---|---|---|
 | `-n, --name` | `run-[DATETIME]` | Experiment name |
 | `-c, --cmd` | `python scripts/train.py` | Command to run |
-| `-e, --environment` | `Free Tier` | Training environment name (see `hafnia experiment environments`) |
+| `-e, --environment` | `Lite` | Training environment name (see `hafnia experiment environments`) |
 | `-d, --dataset` | | Dataset name (e.g. `mnist`) |
 | `-r, --recipe` | | Dataset recipe name |
 | `--recipe-id` | | Dataset recipe ID |
@@ -232,7 +232,7 @@ hafnia experiment create \
   --recipe my-recipe \
   --trainer-id 5e454c0d-fdf1-4d1f-9732-771d7fecd28e \
   --name "My Experiment" \
-  --environment "Free Tier"
+  --environment "Lite"
 
 # List available datasets
 hafnia dataset ls --search coco --ordering -traceability_score

--- a/src/hafnia/platform/__init__.py
+++ b/src/hafnia/platform/__init__.py
@@ -7,7 +7,7 @@ from hafnia.platform.download import (
 from hafnia.platform.experiment import (
     create_experiment,
     get_environments,
-    get_exp_environment_id,
+    get_exp_environment_id_from_name,
     get_experiments,
     pretty_print_experiments,
     pretty_print_training_environments,
@@ -19,7 +19,7 @@ __all__ = [
     "create_trainer_package",
     "get_trainer_packages",
     "get_trainer_package_by_id",
-    "get_exp_environment_id",
+    "get_exp_environment_id_from_name",
     "get_experiments",
     "pretty_print_experiments",
     "create_experiment",

--- a/src/hafnia/platform/experiment.py
+++ b/src/hafnia/platform/experiment.py
@@ -36,7 +36,14 @@ def get_environments(cfg: Optional[Config] = None) -> List[Dict]:
     cfg = cfg or Config()
     endpoint = cfg.get_platform_endpoint("experiment_environments")
     headers = {"Authorization": cfg.api_key}
-    envs: List[Dict] = http.fetch(endpoint, headers=headers)  # type: ignore[assignment]
+    envs: List[Dict] = http.fetch(endpoint, headers=headers)  # type: ignore
+
+    if not isinstance(envs, list):
+        raise ValueError(f"Expected list of environments from API, got: {envs}")
+
+    # Endpoint does not support sorting; sort client-side by the platform-provided 'order' field
+    # so callers can rely on a stable, intentional ordering (e.g. the first entry is the default).
+    envs.sort(key=lambda env: env.get("order") if env.get("order") is not None else float("inf"))  # type: ignore
     return envs
 
 
@@ -58,7 +65,7 @@ def pretty_print_training_environments(envs: List[Dict]) -> None:
     )
 
 
-def get_exp_environment_id(name: str, cfg: Optional[Config] = None) -> str:
+def get_exp_environment_id_from_name(name: str, cfg: Optional[Config] = None) -> str:
     envs = get_environments(cfg=cfg)
 
     for env in envs:

--- a/src/hafnia_cli/experiment_cmds.py
+++ b/src/hafnia_cli/experiment_cmds.py
@@ -112,9 +112,11 @@ def default_experiment_run_name():
     "-e",
     "--environment",
     type=str,
-    default="Free Tier",
-    show_default=True,
-    help="Experiment environment name. View available environments with 'hafnia experiment environments'",
+    default=None,
+    help=(
+        "Experiment environment name. View available environments with 'hafnia experiment environments'. "
+        "Defaults to the first environment returned by the platform (sorted by 'order')."
+    ),
 )
 @click.pass_obj
 def cmd_create_experiment(
@@ -126,7 +128,7 @@ def cmd_create_experiment(
     dataset: Optional[str],
     recipe: Optional[str],
     recipe_id: Optional[str],
-    environment: str,
+    environment: Optional[str],
 ) -> None:
     """
     Create and launch a new experiment run
@@ -146,9 +148,10 @@ def cmd_create_experiment(
 
     \b
     # Show available options:
-    hafnia experiment create --name "My Experiment" -d mnist --cmd "python scripts/train.py" -e "Free Tier" -p ../trainer-classification
+    hafnia experiment create --name "My Experiment" -d mnist --cmd "python scripts/train.py" -e "Lite" -p ../trainer-classification
     """
-    from hafnia.platform import create_experiment, get_exp_environment_id
+    from hafnia.platform import create_experiment, get_exp_environment_id_from_name
+    from hafnia.platform.experiment import get_environments
 
     dataset_recipe_response = get_dataset_recipe_by_identifiers(
         cfg=cfg,
@@ -159,7 +162,16 @@ def cmd_create_experiment(
     recipe_id = dataset_recipe_response["id"]
 
     trainer_id = get_trainer_package_by_identifiers(cfg=cfg, trainer_path=trainer_path, trainer_id=trainer_id)
-    env_id = get_exp_environment_id(environment, cfg=cfg)
+
+    if environment is None:
+        envs = get_environments(cfg=cfg)
+        if not envs:
+            raise click.ClickException("No experiment environments available on the platform.")
+        # Pick the first environment (defined by the order-field provided by the platform)
+        # as the default if no environment is specified
+        env_id = envs[0]["id"]
+    else:
+        env_id = get_exp_environment_id_from_name(name=environment, cfg=cfg)
 
     experiment = create_experiment(
         experiment_name=name,


### PR DESCRIPTION
Previously the Hafnia CLI would use the "Free Tier" Experiment Environment by default. We are now changing this to instead use the first Experiment Environment by default. This allows us to rename Experiment Environments without breaking the SDK
<img width="1716" height="939" alt="image" src="https://github.com/user-attachments/assets/85db8c75-a8a5-4958-8e36-990a0fedb17a" />
