### PR TITLE
Fix-Save-apiKey-keychain-bug. Implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hafnia"
-version = "0.7.7"
+version = "0.7.8"
 description = "Python SDK for communication with Hafnia platform."
 readme = "README.md"
 authors = [

--- a/src/hafnia/utils.py
+++ b/src/hafnia/utils.py
@@ -166,7 +166,7 @@ def show_trainer_package_content(recipe_path: Path, style: str = "emoji", depth_
     recipe = seedir.FakeDir("recipe")
     scan(recipe, zipfile.Path(recipe_path))
     rprint(recipe.seedir(sort=True, first="folders", style=style, printout=False))
-    user_logger.info(f"Recipe size: {size_human_readable(os.path.getsize(recipe_path))}. Max size 800 MiB")
+    user_logger.info(f"Recipe size: {size_human_readable(os.path.getsize(recipe_path))}. Max size 2 GiB")
 
 
 def get_dataset_path_in_hafnia_cloud() -> Path:

--- a/src/hafnia_cli/__main__.py
+++ b/src/hafnia_cli/__main__.py
@@ -41,7 +41,6 @@ def configure(cfg: Config) -> None:
 
     cfg_profile = ConfigSchema(platform_url=platform_url, api_key=api_key, use_keychain=use_keychain)
     cfg.add_profile(profile_name, cfg_profile, set_active=True)
-    cfg.save_config()
     profile_cmds.profile_show(cfg)
 
 

--- a/src/hafnia_cli/config.py
+++ b/src/hafnia_cli/config.py
@@ -190,8 +190,14 @@ class Config:
             if profile_data.get("use_keychain", False):
                 api_key = profile_data.get("api_key")
                 if api_key:
-                    keychain.store_api_key(profile_name, api_key)
-                profile_data["api_key"] = None
+                    if keychain.store_api_key(profile_name, api_key):
+                        profile_data["api_key"] = None
+                    else:
+                        sys_logger.warning(
+                            f"Keychain storage failed for profile '{profile_name}', API key stored in config file as fallback"
+                        )
+                else:
+                    profile_data["api_key"] = None
 
         with open(self.config_path, "w") as f:
             json.dump(config_to_save, f, indent=4)

--- a/src/hafnia_cli/keychain.py
+++ b/src/hafnia_cli/keychain.py
@@ -32,7 +32,7 @@ def store_api_key(profile_name: str, api_key: str) -> bool:
         return False
 
     try:
-        keyring.set_password(KEYRING_SERVICE_NAME, profile_name, api_key)
+        keyring.set_password(KEYRING_SERVICE_NAME, profile_name, api_key[:])
         sys_logger.debug(f"Stored API key for profile '{profile_name}' in keychain")
         return True
     except Exception as e:

--- a/uv.lock
+++ b/uv.lock
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "hafnia"
-version = "0.7.7"
+version = "0.7.8"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

Fixes API key not being stored correctly when using `hafnia configure` on Windows with the system keychain option.

### Expected behaviour

When running `hafnia configure` and answering **Yes** to *"Store API key in system keychain?"*,
the key is saved in **Windows Credential Manager** and `config.json` will correctly show:

```json
"api_key": null,
"use_keychain": true
```

This is intentional — `null` in the file means the key is safely stored in the OS keychain,
not that it is missing.

### What was broken

The root cause was that `SecretStr` (the internal type used to mask the API key in logs)
overrides `__str__()` to return `"********"`. The `keyring` library calls `str()` on the
password internally, so it was storing the literal string `"********"` in Windows Credential
Manager instead of the real key. The storage appeared to succeed, but any subsequent API call
would fail because the retrieved key was `"********"`, not the actual value.

A second bug meant that if keychain storage failed (e.g. restricted environments, headless
sessions), the key was silently wiped from `config.json` with no fallback, leaving the user
with no key stored anywhere.

### Changes

| # | File | Bug | Fix |
|---|---|---|---|
| 1 | `keychain.py` | `str(SecretStr)` → `"********"` stored in keychain | Use `api_key[:]` to extract the real string value before passing to keyring |
| 2 | `config.py` (`save_config`) | Keychain failure silently wiped the key from `config.json` | Only clear `api_key` from the file if keychain storage actually succeeded; otherwise fall back to storing in the file |
| 3 | `__main__.py` (`configure`) | Redundant double `save_config()` call | Removed — `add_profile` already calls it internally |
