### PR TITLE
Handling various edge cases for hafnia

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hafnia"
-version = "0.7.8"
+version = "0.7.9"
 description = "Python SDK for communication with Hafnia platform."
 readme = "README.md"
 authors = [

--- a/src/hafnia/dataset/dataset_details_uploader.py
+++ b/src/hafnia/dataset/dataset_details_uploader.py
@@ -507,11 +507,17 @@ def recent_annotation_date(dataset: HafniaDataset, primitive_field: str) -> Opti
     columns_with_field = [
         col for col in PRIMITIVE_COLUMN_NAMES if has_primitive_field(dataset.samples, col, primitive_field)
     ]
-    if len(columns_with_field) == 0:
+
+    candidates: List[datetime] = []
+    for col in columns_with_field:
+        exploded = dataset.samples[col].explode().drop_nulls()
+        if exploded.is_empty():
+            continue
+        values = exploded.struct.field(primitive_field).drop_nulls().to_list()
+        candidates.extend(v for v in values if v is not None)
+    if len(candidates) == 0:
         return None
-    exprs = [pl.col(col).list.eval(pl.element().struct.field(primitive_field)).list.max() for col in columns_with_field]
-    annotation_date = dataset.samples.select(pl.max_horizontal(exprs).max()).item()
-    return annotation_date
+    return max(candidates)
 
 
 def create_reports_from_primitive(

--- a/src/hafnia/dataset/dataset_details_uploader.py
+++ b/src/hafnia/dataset/dataset_details_uploader.py
@@ -513,8 +513,10 @@ def recent_annotation_date(dataset: HafniaDataset, primitive_field: str) -> Opti
         exploded = dataset.samples[col].explode().drop_nulls()
         if exploded.is_empty():
             continue
-        values = exploded.struct.field(primitive_field).drop_nulls().to_list()
-        candidates.extend(v for v in values if v is not None)
+        values = exploded.struct.field(primitive_field).drop_nulls()
+        if values.is_empty():
+            continue
+        candidates.append(values.max())
     if len(candidates) == 0:
         return None
     return max(candidates)

--- a/src/hafnia/dataset/hafnia_dataset.py
+++ b/src/hafnia/dataset/hafnia_dataset.py
@@ -179,8 +179,8 @@ class HafniaDataset:
         path_local: Path,
         session: "boto3.Session",
         version: Optional[str] = None,
-        download_files: bool = True,
         force_redownload: bool = False,
+        download_files: bool = True,
     ) -> "HafniaDataset":
         """Download a Hafnia dataset from a user-controlled S3 bucket.
 
@@ -189,8 +189,8 @@ class HafniaDataset:
             path_local: Local folder to download into.
             session: Boto3 session used to obtain credentials.
             version: Dataset version string (e.g. ``"0.1.0"``) or ``None`` for latest.
-            download_files: If ``False``, to only download metadata files. ``True`` by default to also download dataset images/videos.
             force_redownload: If ``True``, re-download data files that already exist locally.
+            download_files: If ``False``, to only download metadata files. ``True`` by default to also download dataset images/videos.
         """
         from hafnia.dataset.operations.dataset_s3_storage import download_dataset_from_s3
 
@@ -199,8 +199,8 @@ class HafniaDataset:
             path_local=path_local,
             session=session,
             version=version,
-            download_files=download_files,
             force_redownload=force_redownload,
+            download_files=download_files,
         )
 
     def to_s3(

--- a/src/hafnia/dataset/hafnia_dataset.py
+++ b/src/hafnia/dataset/hafnia_dataset.py
@@ -11,7 +11,10 @@ from packaging.version import Version
 
 from hafnia import utils
 from hafnia.dataset import dataset_helpers
-from hafnia.dataset.benchmark.metrics import classification_metrics, object_detection_metrics
+from hafnia.dataset.benchmark.metrics import (
+    classification_metrics,
+    object_detection_metrics,
+)
 from hafnia.dataset.dataset_helpers import is_valid_version_string, version_from_string
 from hafnia.dataset.dataset_names import (
     TAG_IS_SAMPLE,
@@ -176,6 +179,7 @@ class HafniaDataset:
         path_local: Path,
         session: "boto3.Session",
         version: Optional[str] = None,
+        download_files: bool = True,
         force_redownload: bool = False,
     ) -> "HafniaDataset":
         """Download a Hafnia dataset from a user-controlled S3 bucket.
@@ -185,6 +189,7 @@ class HafniaDataset:
             path_local: Local folder to download into.
             session: Boto3 session used to obtain credentials.
             version: Dataset version string (e.g. ``"0.1.0"``) or ``None`` for latest.
+            download_files: If ``False``, to only download metadata files. ``True`` by default to also download dataset images/videos.
             force_redownload: If ``True``, re-download data files that already exist locally.
         """
         from hafnia.dataset.operations.dataset_s3_storage import download_dataset_from_s3
@@ -194,6 +199,7 @@ class HafniaDataset:
             path_local=path_local,
             session=session,
             version=version,
+            download_files=download_files,
             force_redownload=force_redownload,
         )
 

--- a/src/hafnia/dataset/operations/dataset_s3_storage.py
+++ b/src/hafnia/dataset/operations/dataset_s3_storage.py
@@ -1,3 +1,6 @@
+import hashlib
+import ipaddress
+import re
 import tempfile
 import time
 from pathlib import Path
@@ -12,11 +15,21 @@ from hafnia.dataset.dataset_names import (
     DatasetVariant,
     SampleField,
 )
-from hafnia.dataset.hafnia_dataset import HafniaDataset, download_meta_dataset_files_from_version
+from hafnia.dataset.hafnia_dataset import (
+    HafniaDataset,
+    download_meta_dataset_files_from_version,
+)
 from hafnia.log import user_logger
 from hafnia.platform import s5cmd_utils
-from hafnia.platform.datasets import get_read_credentials_by_name, get_upload_credentials
-from hafnia.platform.s5cmd_utils import AwsCredentials, ResourceCredentials, fast_copy_files
+from hafnia.platform.datasets import (
+    get_read_credentials_by_name,
+    get_upload_credentials,
+)
+from hafnia.platform.s5cmd_utils import (
+    AwsCredentials,
+    ResourceCredentials,
+    fast_copy_files,
+)
 from hafnia.utils import progress_bar
 from hafnia_cli.config import Config
 
@@ -69,6 +82,55 @@ def delete_hafnia_dataset_files_from_resource_credentials(
     return True
 
 
+def validate_bucket_name_by_s3_rules(bucket_name: str) -> None:
+    """Validate ``bucket_name`` against AWS S3 general-purpose bucket naming rules.
+
+    This is a pure string check — it cannot detect global-uniqueness conflicts
+    or ownership issues, only names that S3 will reject outright. Raises
+    ``ValueError`` describing the first violated rule.
+
+    See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+
+    # Thank you Claude!
+    """
+    if not isinstance(bucket_name, str):
+        raise ValueError(f"Bucket name must be a string, got {type(bucket_name).__name__}.")
+
+    n = len(bucket_name)
+    if n < 3 or n > 63:
+        raise ValueError(f"Bucket name must be 3-63 characters long, got {n}: {bucket_name!r}.")
+
+    _BUCKET_NAME_CHARSET = re.compile(r"^[a-z0-9.\-]+$")
+    if not _BUCKET_NAME_CHARSET.match(bucket_name):
+        raise ValueError(
+            f"Bucket name {bucket_name!r} contains invalid characters. "
+            "Only lowercase letters, numbers, dots (.) and hyphens (-) are allowed."
+        )
+
+    if not (bucket_name[0].isalnum() and bucket_name[-1].isalnum()):
+        raise ValueError(f"Bucket name {bucket_name!r} must begin and end with a lowercase letter or number.")
+
+    if ".." in bucket_name:
+        raise ValueError(f"Bucket name {bucket_name!r} must not contain two adjacent periods.")
+
+    try:
+        ipaddress.IPv4Address(bucket_name)
+    except ipaddress.AddressValueError:
+        pass
+    else:
+        raise ValueError(f"Bucket name {bucket_name!r} must not be formatted as an IPv4 address.")
+
+    forbidden_prefixes = ("xn--", "sthree-", "amzn-s3-demo-")
+    for prefix in forbidden_prefixes:
+        if bucket_name.startswith(prefix):
+            raise ValueError(f"Bucket name {bucket_name!r} must not start with the reserved prefix {prefix!r}.")
+
+    forbidden_suffixes = ("-s3alias", "--ol-s3", ".mrap", "--x-s3", "--table-s3")
+    for suffix in forbidden_suffixes:
+        if bucket_name.endswith(suffix):
+            raise ValueError(f"Bucket name {bucket_name!r} must not end with the reserved suffix {suffix!r}.")
+
+
 def _ensure_s3_bucket_exists(session: boto3.Session, bucket_name: str) -> None:
     """Create ``bucket_name`` if it does not already exist.
 
@@ -77,6 +139,7 @@ def _ensure_s3_bucket_exists(session: boto3.Session, bucket_name: str) -> None:
     (e.g. 403 Forbidden — bucket exists but is owned by someone else) is
     re-raised so the caller does not silently overwrite or proceed.
     """
+    validate_bucket_name_by_s3_rules(bucket_name)
     s3_client = session.client("s3")
     try:
         s3_client.head_bucket(Bucket=bucket_name)
@@ -101,6 +164,7 @@ def download_dataset_from_s3(
     session: boto3.Session,
     version: Optional[str] = None,
     force_redownload: bool = False,
+    download_files: bool = True,
 ) -> HafniaDataset:
     """Download a Hafnia dataset from a user-controlled S3 bucket.
 
@@ -115,16 +179,23 @@ def download_dataset_from_s3(
         path_local: Local folder to download into.
         session: Boto3 session used to obtain credentials.
         version: Dataset version string (e.g. ``"0.1.0"``) or ``None`` for latest.
+        download_files: If ``False``, to only download metadata files. ``True`` by default to also download dataset images/videos.
         force_redownload: If ``True``, re-download data files that already
             exist locally.
     """
     resource_credentials = AwsCredentials.from_session(session=session).to_resource_credentials(bucket_prefix)
 
     download_meta_dataset_files_from_version(
-        resource_credentials=resource_credentials, version=version, path_dataset=path_local
+        resource_credentials=resource_credentials,
+        version=version,
+        path_dataset=path_local,
     )
 
     dataset = HafniaDataset.from_path(path_local, check_for_images=False)
+
+    if not download_files:
+        return dataset
+
     dataset = sync_dataset_files_from_s3(
         dataset,
         path_local,
@@ -312,23 +383,68 @@ def sync_dataset_files_to_platform_from_resource_credentials(
 MISSING_LOCALLY_COLUMN = "MissingLocally"
 
 
+MAX_PATH_LENGTH = 255
+
+
+def local_path_from_remote_path(
+    remote_src_path: str,
+    path_data: Path,
+    extend_name_by_subfolder: Optional[int],
+) -> str:
+    """Build the local download path for a remote S3 source path.
+
+    The remote path is flattened into a single filename under ``path_data`` by
+    joining its parts with ``-``. If the resulting absolute path would exceed
+    ``MAX_PATH_LENGTH``, the filename is replaced with a short sha1-derived
+    hash of itself (keeping the original suffix) so the path fits on common
+    filesystems.
+    """
+    if extend_name_by_subfolder is not None and extend_name_by_subfolder < 0:
+        raise ValueError(f"'extend_name_by_subfolder' must be a non-negative integer. Got {extend_name_by_subfolder}.")
+
+    path_parts_all = remote_src_path.split("/")
+    if extend_name_by_subfolder is None:
+        path_parts = path_parts_all[2:]  # Drops "s3://" prefix
+    else:
+        path_parts = path_parts_all[-(extend_name_by_subfolder + 1) :]
+
+    filename = "-".join(path_parts)
+    local_path_str = (path_data / filename).absolute().as_posix()
+    if len(local_path_str) <= MAX_PATH_LENGTH:
+        return local_path_str
+
+    suffix = Path(filename).suffix
+    hash_part = hashlib.sha1(filename.encode()).hexdigest()
+    shortened_path_str = (path_data / hash_part).with_suffix(suffix).absolute().as_posix()
+
+    user_logger.warning(
+        f"Generated filename '{filename}' exceeds MAX_PATH_LENGTH={MAX_PATH_LENGTH}. "
+        f"Shortened to '{shortened_path_str}'."
+    )
+    if len(shortened_path_str) > MAX_PATH_LENGTH:
+        raise ValueError(
+            f"Even after shortening, local path '{shortened_path_str}' exceeds MAX_PATH_LENGTH={MAX_PATH_LENGTH}. "
+            "Consider storing the dataset in a folder with a shorter path."
+        )
+    return shortened_path_str
+
+
 def _resolve_local_download_paths(
     dataset: HafniaDataset,
     path_output_folder: Path,
-    extend_name_by_subfolder: int,
+    extend_name_by_subfolder: Optional[int],
     subfolder_name: str,
 ) -> Tuple[HafniaDataset, pl.DataFrame]:
-    if extend_name_by_subfolder < 0:
-        raise ValueError(f"'extend_name_by_subfolder' must be a non-negative integer. Got {extend_name_by_subfolder}.")
-
     path_data = path_output_folder / subfolder_name
     path_data.mkdir(parents=True, exist_ok=True)
 
     update_rows = []
     for remote_src_path in dataset.samples[SampleField.REMOTE_PATH].unique().to_list():
-        path_parts = remote_src_path.split("/")
-        filename = "_".join(path_parts[-(1 + extend_name_by_subfolder) :])
-        local_path_str = (path_data / filename).absolute().as_posix()
+        local_path_str = local_path_from_remote_path(
+            remote_src_path=remote_src_path,
+            path_data=path_data,
+            extend_name_by_subfolder=extend_name_by_subfolder,
+        )
         update_rows.append(
             {
                 SampleField.REMOTE_PATH: remote_src_path,
@@ -350,7 +466,7 @@ def sync_files_from_platform(
     dataset: HafniaDataset,
     path_output_folder: Path,
     force_redownload: bool = False,
-    extend_name_by_subfolder: int = 0,
+    extend_name_by_subfolder: Optional[int] = None,
     subfolder_name: str = "data",
     cfg: Optional[Config] = None,
 ) -> HafniaDataset:
@@ -366,6 +482,10 @@ def sync_files_from_platform(
         force_redownload: If ``True``, re-download files that already exist locally.
         extend_name_by_subfolder: Number of trailing remote path segments to fold
             into the local filename (useful when remote paths share a basename).
+            Default ``None`` uses the full remote path minus the leading "s3://" prefix
+            and replaces "/" with "-" to create the local filename.
+            E.g for remote path "s3://bucket-name/sample/data/e2/b0/e2b000ac47b19a999bee5456a6addb88.png"
+            -> filename "data-e2-b0-e2b000ac47b19a999bee5456a6addb88.png" with ``extend_name_by_subfolder=None``
         subfolder_name: Subfolder under ``path_output_folder`` to write data into.
         cfg: Optional Hafnia CLI config; defaults to a fresh ``Config()``.
     """
@@ -424,7 +544,7 @@ def sync_dataset_files_from_s3(
     path_output_folder: Path,
     aws_credentials: AwsCredentials,
     force_redownload: bool = False,
-    extend_name_by_subfolder: int = 0,
+    extend_name_by_subfolder: Optional[int] = None,
     subfolder_name: str = "data",
 ) -> HafniaDataset:
     dataset, download_df = _resolve_local_download_paths(

--- a/src/hafnia/dataset/operations/dataset_s3_storage.py
+++ b/src/hafnia/dataset/operations/dataset_s3_storage.py
@@ -82,6 +82,9 @@ def delete_hafnia_dataset_files_from_resource_credentials(
     return True
 
 
+_BUCKET_NAME_CHARSET = re.compile(r"^[a-z0-9.\-]+$")
+
+
 def validate_bucket_name_by_s3_rules(bucket_name: str) -> None:
     """Validate ``bucket_name`` against AWS S3 general-purpose bucket naming rules.
 
@@ -100,7 +103,6 @@ def validate_bucket_name_by_s3_rules(bucket_name: str) -> None:
     if n < 3 or n > 63:
         raise ValueError(f"Bucket name must be 3-63 characters long, got {n}: {bucket_name!r}.")
 
-    _BUCKET_NAME_CHARSET = re.compile(r"^[a-z0-9.\-]+$")
     if not _BUCKET_NAME_CHARSET.match(bucket_name):
         raise ValueError(
             f"Bucket name {bucket_name!r} contains invalid characters. "

--- a/src/hafnia/dataset/operations/dataset_s3_storage.py
+++ b/src/hafnia/dataset/operations/dataset_s3_storage.py
@@ -179,9 +179,10 @@ def download_dataset_from_s3(
         path_local: Local folder to download into.
         session: Boto3 session used to obtain credentials.
         version: Dataset version string (e.g. ``"0.1.0"``) or ``None`` for latest.
-        download_files: If ``False``, to only download metadata files. ``True`` by default to also download dataset images/videos.
         force_redownload: If ``True``, re-download data files that already
             exist locally.
+        download_files: If ``False``, to only download metadata files. ``True`` by default to also download
+            dataset images/videos.
     """
     resource_credentials = AwsCredentials.from_session(session=session).to_resource_credentials(bucket_prefix)
 
@@ -417,7 +418,7 @@ def local_path_from_remote_path(
     hash_part = hashlib.sha1(filename.encode()).hexdigest()
     shortened_path_str = (path_data / hash_part).with_suffix(suffix).absolute().as_posix()
 
-    user_logger.warning(
+    user_logger.debug(
         f"Generated filename '{filename}' exceeds MAX_PATH_LENGTH={MAX_PATH_LENGTH}. "
         f"Shortened to '{shortened_path_str}'."
     )

--- a/tests/unit/dataset/operations/test_dataset_s3_storage.py
+++ b/tests/unit/dataset/operations/test_dataset_s3_storage.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+
+import pytest
+
+from hafnia.dataset.operations.dataset_s3_storage import (
+    MAX_PATH_LENGTH,
+    local_path_from_remote_path,
+    validate_bucket_name_by_s3_rules,
+)
+
+
+@pytest.mark.parametrize(
+    "bucket_name",
+    [
+        "abc",
+        "my-bucket",
+        "my.bucket.name",
+        "bucket123",
+        "a1b2c3",
+        "my-very-long-but-still-valid-bucket-name-with-63-characters-abc",  # 63 chars
+        "1bucket",  # may start with a digit
+        "bucket1",
+        "a-b",
+        "192-168-5-4",  # IP-like but not an IP
+    ],
+)
+def test_validate_bucket_name_by_s3_rules_valid(bucket_name: str):
+    validate_bucket_name_by_s3_rules(bucket_name)
+
+
+@pytest.mark.parametrize(
+    ("bucket_name", "reason"),
+    [
+        ("ab", "too short"),
+        ("a" * 64, "too long"),
+        ("", "empty string"),
+        ("My-Bucket", "uppercase letters"),
+        ("my_bucket", "underscore not allowed"),
+        ("my bucket", "space not allowed"),
+        ("my/bucket", "slash not allowed"),
+        ("bucket!", "exclamation not allowed"),
+        ("-bucket", "starts with hyphen"),
+        ("bucket-", "ends with hyphen"),
+        (".bucket", "starts with period"),
+        ("bucket.", "ends with period"),
+        ("my..bucket", "adjacent periods"),
+        ("192.168.5.4", "IPv4 address"),
+        ("10.0.0.1", "IPv4 address"),
+        ("xn--bucket", "reserved xn-- prefix"),
+        ("sthree-bucket", "reserved sthree- prefix"),
+        ("amzn-s3-demo-bucket", "reserved amzn-s3-demo- prefix"),
+        ("bucket-s3alias", "reserved -s3alias suffix"),
+        ("bucket--ol-s3", "reserved --ol-s3 suffix"),
+        ("bucket.mrap", "reserved .mrap suffix"),
+        ("bucket--x-s3", "reserved --x-s3 suffix"),
+        ("bucket--table-s3", "reserved --table-s3 suffix"),
+    ],
+)
+def test_validate_bucket_name_by_s3_rules_invalid(bucket_name: str, reason: str):
+    with pytest.raises(ValueError):
+        validate_bucket_name_by_s3_rules(bucket_name)
+
+
+def test_validate_bucket_name_by_s3_rules_non_string():
+    with pytest.raises(ValueError):
+        validate_bucket_name_by_s3_rules(12345)  # type: ignore[arg-type]
+
+
+LONG_NAME1 = "s3://mdi-pre-labelling/detection/eulm/outputs/goa_pedestrian_random_test_20260212_233106/genoa-1-split/5min/lan0281_-_via_avio_portici/2025/08/09/12/2025-08-09T121055+0100_2025-08-09T124055+0100_redacted_seg003/2025-08-09T121055+0100_2025-08-09T124055+0100_redacted_seg003/000000.jpg"
+LONG_NAME2 = "s3://mdi-pre-labelling.s3.eu-west-1.amazonaws.com/detection/eulm/outputs/goa_pedestrian_random_test_20260212_233106/genoa-1-split/5min/lan0281_-_via_avio_portici/2025/08/09/12/2025-08-09T121055+0100_2025-08-09T124055+0100_redacted_seg003/2025-08-09T121055+0100_2025-08-09T124055+0100_redacted_seg003/000000.jpg"
+
+
+@pytest.mark.parametrize(
+    ("remote_src_path", "extend_name_by_subfolder", "expected_filename"),
+    [
+        # extend=None drops the "s3://" prefix and joins the remaining parts with "-".
+        ("s3://my-bucket/folder/image.jpg", None, "my-bucket-folder-image.jpg"),
+        ("s3://b/short.png", None, "b-short.png"),
+        # extend_name_by_subfolder keeps the basename plus N trailing segments.
+        ("s3://bucket/a/b/image.jpg", 0, "image.jpg"),
+        ("s3://bucket/a/b/image.jpg", 1, "b-image.jpg"),
+        ("s3://bucket/a/b/image.jpg", 2, "a-b-image.jpg"),
+        ("s3://bucket/a/b/image.jpg", 3, "bucket-a-b-image.jpg"),
+        # Long path → sha1-shortened filename (suffix preserved).
+        (LONG_NAME1, None, "786aa96d0b6cc7ece649e4ee8f9dcebb989a33e7.jpg"),
+        (LONG_NAME2, None, "9068e98d6a9d578fa4e8ae2aaa05376bec5905cd.jpg"),
+        (f"s3://bucket1/{'y' * 300}/image.jpg", None, "e111fa29e9cf9422d6cdc3c91cb4a2284a43ed36.jpg"),
+        (f"s3://bucket/{'x' * 300}/image.jpg", None, "5f41c2190123fc1d9c7c5467888ad41c34853fa1.jpg"),
+        (f"s3://bucket2/{'y' * 300}/image.jpg", None, "eaf6adc827c7bbdd4405cad68a779e9d42b74431.jpg"),
+        # Long path with no suffix → hash-only filename, no suffix.
+        (f"s3://bucket/{'z' * 300}/no_extension_file", None, "43476be47179ca9b063282ac1ec55c2ea59b55fd"),
+    ],
+)
+def test_local_path_from_remote_path(
+    tmp_path: Path,
+    remote_src_path: str,
+    extend_name_by_subfolder: int | None,
+    expected_filename: str,
+):
+    result = local_path_from_remote_path(
+        remote_src_path=remote_src_path,
+        path_data=tmp_path,
+        extend_name_by_subfolder=extend_name_by_subfolder,
+    )
+    assert result == (tmp_path / expected_filename).absolute().as_posix()
+    assert len(result) <= MAX_PATH_LENGTH
+
+
+def test_local_path_from_remote_path_raises_conditions(tmp_path: Path):
+    # 1) Build a path_data so long that even hash + suffix won't fit under MAX_PATH_LENGTH.
+    deep = tmp_path
+    while len(deep.absolute().as_posix()) < MAX_PATH_LENGTH:
+        deep = deep / ("d" * 20)
+    deep.mkdir(parents=True, exist_ok=True)
+
+    long_remote = f"s3://bucket/{'q' * 300}/image.jpg"
+    with pytest.raises(ValueError, match="exceeds MAX_PATH_LENGTH"):
+        local_path_from_remote_path(long_remote, deep, extend_name_by_subfolder=None)
+
+    # 2) Negative extend_name_by_subfolder should raise ValueError.
+    with pytest.raises(ValueError, match="must be a non-negative integer"):
+        local_path_from_remote_path(
+            remote_src_path="s3://bucket/a/b/image.jpg",
+            path_data=tmp_path,
+            extend_name_by_subfolder=-1,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "hafnia"
-version = "0.7.8"
+version = "0.7.9"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Adding a few fixes related to remote datasets. 
- Add this `validate_bucket_name_by_s3_rules` function to do a quick check if a bucket name is valid. 
- Add this `local_path_from_remote_path` function. This converts a remote S3 path (prefix) to a local filename. This is used when downloading files from s3 to a local path. Previously I would use the s3 prefix filename to name the download file. However, the issue with this approach is that s3 files with the same "filename" will overwrite each other. E.g. if I download these files `s3://some/bucket/prefix/image0.png` and `s3://another/bucket/prefix/image0.png` from S3 they would both be stored in `data/image0.png` - which would cause one of them being overwritten. I then introduced using the whole prefix replacing `/` with `-` so it beomes `some-bucket-prefix-image0.png` and `another-bucket-prefix-image0.png`.... However, for very long prefixes I will hit the maximum path length (commonly 255 chars)... So for these cases I would then use the path hash instead. 
