### PR TITLE
Command builder adjustments

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -96,11 +96,16 @@
             "args": [
                 "trainer",
                 "create",
-                "${workspaceFolder}/../trainer-classification",
+                // "${workspaceFolder}/../trainer-classification",
+                // "--name",
+                // "Classification Trainer Package Launched in debug mode from vc-code",
+                // "--description",
+                // "A trainer package for image classification tasks launched in debug mode."
+                "${workspaceFolder}/../trainer-object-detection",
                 "--name",
-                "Classification Trainer Package Launched in debug mode from vc-code",
+                "Object Detection Trainer Package Launched in debug mode from vc-code",
                 "--description",
-                "A trainer package for image classification tasks launched in debug mode."
+                "A trainer package for object detection tasks launched in debug mode."
             ]
         },
         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hafnia"
-version = "0.7.9"
+version = "0.7.10"
 description = "Python SDK for communication with Hafnia platform."
 readme = "README.md"
 authors = [

--- a/src/hafnia/experiment/command_builder.py
+++ b/src/hafnia/experiment/command_builder.py
@@ -42,7 +42,6 @@ from pydantic import BaseModel, ConfigDict, Field, create_model, model_validator
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
-DEFAULT_N_POSITIONAL_ARGS: int = 0
 DEFAULT_CASE_CONVERSION: Literal["none", "kebab"] = "none"
 DEFAULT_PARAMETER_PREFIX: str = "--"
 DEFAULT_NESTED_PARAMETER_HANDLING: Literal["dot", "not-supported"] = "dot"
@@ -54,7 +53,7 @@ DEFAULT_ORDER: int = 100
 def auto_save_command_builder_schema(
     cli_function: Callable[..., Any],
     name: Optional[str] = None,
-    n_positional_args: int = DEFAULT_N_POSITIONAL_ARGS,
+    positional_args: Optional[List[str]] = None,
     cli_tool: Optional[str] = "cyclopts",
     ignore_params: tuple[str, ...] = (),
     handle_union_types: bool = True,
@@ -65,7 +64,7 @@ def auto_save_command_builder_schema(
     nested_parameter_handling: Optional[Literal["dot", "not-supported"]] = None,
     assignment_separator: Optional[Literal["space", "equals"]] = None,
     bool_handling: Optional[Literal["none", "flag-negation"]] = None,
-    order: Optional[int] = None,
+    order: int = DEFAULT_ORDER,
 ) -> Path:
     """
     Magic function to create and save CommandBuilderSchema as JSON file from a CLI function.
@@ -87,21 +86,20 @@ def auto_save_command_builder_schema(
         parameter_prefix="--",
         nested_parameter_handling="dot",
         assignment_separator="space",
-        n_positional_args=0,
         bool_handling="flag-negation",
     )
     command_builder.to_json_file(Path("scripts/train.json"))
 
     """
 
-    launch_schema = CommandBuilderSchema.from_function(
+    launch_schema: CommandBuilderSchema = CommandBuilderSchema.from_function(
         cli_function,
         name=name,
         cli_tool=cli_tool,
         ignore_params=ignore_params,
         handle_union_types=handle_union_types,
         cmd=cmd,
-        n_positional_args=n_positional_args,
+        positional_args=positional_args,
         case_conversion=case_conversion,
         parameter_prefix=parameter_prefix,
         nested_parameter_handling=nested_parameter_handling,
@@ -143,16 +141,6 @@ class CommandBuilderSchema(BaseModel):
     json_schema: Dict[str, Any] = Field(
         default_factory=dict,
         description="JSON schema representing the command parameters. ",
-    )
-
-    n_positional_args: int = Field(
-        DEFAULT_N_POSITIONAL_ARGS,
-        description=(
-            "Number of positional arguments in the command. To handle that some CLI tools "
-            "accept positional arguments before options, this specifies how many positional arguments are expected. "
-            "These will be filled in order before any named arguments. "
-            "E.g. for 'python train.py data/train --batch-size 32', n_positional_args would be 1 ('data/train')."
-        ),
     )
 
     # Below defines how the specified parameters/arguments are formatted as command line arguments
@@ -202,6 +190,11 @@ class CommandBuilderSchema(BaseModel):
         ),
     )
 
+    @property
+    def positional_args(self) -> List[str]:
+        """Names of parameters (from 'json_schema') that are passed as positional command line arguments."""
+        return list(self.json_schema.get("positional_args", []))
+
     def to_json_file(self, path: Path) -> Path:
         """Write the launcher schema to a JSON file.
 
@@ -228,6 +221,15 @@ class CommandBuilderSchema(BaseModel):
                 "Either remove nested parameters from the schema or change "
                 "'nested_parameter_handling' to support nested parameters."
             )
+
+        # Every name listed in 'positional_args' must refer to an actual parameter in 'properties'.
+        properties = self.json_schema.get("properties", {})
+        unknown_positional = [name for name in self.positional_args if name not in properties]
+        if unknown_positional:
+            raise ValueError(
+                f"The 'positional_args' contain names that are not parameters in the 'json_schema' "
+                f"properties: {unknown_positional}. Available parameters: {list(properties)}."
+            )
         return self
 
     @staticmethod
@@ -243,13 +245,13 @@ class CommandBuilderSchema(BaseModel):
         ignore_params: tuple[str, ...] = (),
         cmd: Optional[str] = None,
         handle_union_types: bool = True,
-        n_positional_args: int = DEFAULT_N_POSITIONAL_ARGS,
+        positional_args: Optional[List[str]] = None,
         case_conversion: Optional[Literal["none", "kebab"]] = None,
         parameter_prefix: Optional[str] = None,
         nested_parameter_handling: Optional[Literal["dot", "not-supported"]] = None,
         assignment_separator: Optional[Literal["space", "equals"]] = None,
         bool_handling: Optional[Literal["none", "flag-negation"]] = None,
-        order: Optional[int] = None,
+        order: int = DEFAULT_ORDER,
     ) -> "CommandBuilderSchema":
         cmd = cmd or f"python {path_of_function(cli_function).as_posix()}"
         if cli_tool == "cyclopts":
@@ -276,12 +278,15 @@ class CommandBuilderSchema(BaseModel):
         )
         set_assignment_separator = assignment_separator or set_assignment_separator or DEFAULT_ASSIGNMENT_SEPARATOR
         set_bool_handling = bool_handling or set_bool_handling or DEFAULT_BOOL_HANDLING
-        set_order = DEFAULT_ORDER if order is None else order
         function_schema = schema_from_cli_function(
             cli_function,
             ignore_params=ignore_params,
             handle_union_types=handle_union_types,
         )
+        # Store the positional arguments inside the json_schema so the information travels with the schema.
+        # This is not a standard JSON schema field, but it is used by our Command Builder implementation to
+        # determine which arguments are positional.
+        function_schema["positional_args"] = positional_args or []
         return CommandBuilderSchema(
             name=name,
             cmd=cmd,
@@ -291,8 +296,7 @@ class CommandBuilderSchema(BaseModel):
             nested_parameter_handling=set_nested_parameter_handling,
             assignment_separator=set_assignment_separator,
             bool_handling=set_bool_handling,
-            n_positional_args=n_positional_args,
-            order=set_order,
+            order=order,
         )
 
     def command_args_from_form_data(self, form_data: Dict[str, Any], include_cmd: bool = True) -> List[str]:
@@ -325,11 +329,15 @@ class CommandBuilderSchema(BaseModel):
         if include_cmd:
             cmd_args.extend(self.cmd.split(" "))
 
-        for position, (name, value) in enumerate(form_data.items()):
-            is_positional = position < self.n_positional_args
+        # Emit positional arguments first - in the order listed in 'positional_args' - then the remaining named
+        # arguments in form-data order. Positional names not present in the form data are skipped.
+        positional_names = [name for name in self.positional_args if name in form_data]
+        named_names = [name for name in form_data if name not in positional_names]
+        for name in [*positional_names, *named_names]:
+            is_positional = name in positional_names
             arg_parts = name_and_value_as_command_line_arguments(
                 name=name,
-                value=value,
+                value=form_data[name],
                 is_positional=is_positional,
                 case_conversion=self.case_conversion,
                 parameter_prefix=self.parameter_prefix,

--- a/src/hafnia/experiment/command_builder.py
+++ b/src/hafnia/experiment/command_builder.py
@@ -276,7 +276,7 @@ class CommandBuilderSchema(BaseModel):
         )
         set_assignment_separator = assignment_separator or set_assignment_separator or DEFAULT_ASSIGNMENT_SEPARATOR
         set_bool_handling = bool_handling or set_bool_handling or DEFAULT_BOOL_HANDLING
-        set_order = order or DEFAULT_ORDER
+        set_order = DEFAULT_ORDER if order is None else order
         function_schema = schema_from_cli_function(
             cli_function,
             ignore_params=ignore_params,

--- a/src/hafnia/experiment/command_builder.py
+++ b/src/hafnia/experiment/command_builder.py
@@ -48,6 +48,7 @@ DEFAULT_PARAMETER_PREFIX: str = "--"
 DEFAULT_NESTED_PARAMETER_HANDLING: Literal["dot", "not-supported"] = "dot"
 DEFAULT_ASSIGNMENT_SEPARATOR: Literal["space", "equals"] = "space"
 DEFAULT_BOOL_HANDLING: Literal["none", "flag-negation"] = "none"
+DEFAULT_ORDER: int = 100
 
 
 def auto_save_command_builder_schema(
@@ -64,6 +65,7 @@ def auto_save_command_builder_schema(
     nested_parameter_handling: Optional[Literal["dot", "not-supported"]] = None,
     assignment_separator: Optional[Literal["space", "equals"]] = None,
     bool_handling: Optional[Literal["none", "flag-negation"]] = None,
+    order: Optional[int] = None,
 ) -> Path:
     """
     Magic function to create and save CommandBuilderSchema as JSON file from a CLI function.
@@ -105,6 +107,7 @@ def auto_save_command_builder_schema(
         nested_parameter_handling=nested_parameter_handling,
         assignment_separator=assignment_separator,
         bool_handling=bool_handling,
+        order=order,
     )
 
     path_schema = path_schema or path_of_function(cli_function).with_suffix(".schema.json")
@@ -192,6 +195,13 @@ class CommandBuilderSchema(BaseModel):
         ),
     )
 
+    order: int = Field(
+        100,  # Default order is 100, but can be set to a lower value to be displayed higher in the UI
+        description=(
+            "The order of the command builder in the UI. Command builders with lower order are displayed first. "
+        ),
+    )
+
     def to_json_file(self, path: Path) -> Path:
         """Write the launcher schema to a JSON file.
 
@@ -239,6 +249,7 @@ class CommandBuilderSchema(BaseModel):
         nested_parameter_handling: Optional[Literal["dot", "not-supported"]] = None,
         assignment_separator: Optional[Literal["space", "equals"]] = None,
         bool_handling: Optional[Literal["none", "flag-negation"]] = None,
+        order: Optional[int] = None,
     ) -> "CommandBuilderSchema":
         cmd = cmd or f"python {path_of_function(cli_function).as_posix()}"
         if cli_tool == "cyclopts":
@@ -265,7 +276,7 @@ class CommandBuilderSchema(BaseModel):
         )
         set_assignment_separator = assignment_separator or set_assignment_separator or DEFAULT_ASSIGNMENT_SEPARATOR
         set_bool_handling = bool_handling or set_bool_handling or DEFAULT_BOOL_HANDLING
-
+        set_order = order or DEFAULT_ORDER
         function_schema = schema_from_cli_function(
             cli_function,
             ignore_params=ignore_params,
@@ -281,6 +292,7 @@ class CommandBuilderSchema(BaseModel):
             assignment_separator=set_assignment_separator,
             bool_handling=set_bool_handling,
             n_positional_args=n_positional_args,
+            order=set_order,
         )
 
     def command_args_from_form_data(self, form_data: Dict[str, Any], include_cmd: bool = True) -> List[str]:

--- a/src/hafnia/experiment/command_builder.py
+++ b/src/hafnia/experiment/command_builder.py
@@ -184,7 +184,7 @@ class CommandBuilderSchema(BaseModel):
     )
 
     order: int = Field(
-        100,  # Default order is 100, but can be set to a lower value to be displayed higher in the UI
+        DEFAULT_ORDER,
         description=(
             "The order of the command builder in the UI. Command builders with lower order are displayed first. "
         ),

--- a/src/hafnia/platform/trainer_package.py
+++ b/src/hafnia/platform/trainer_package.py
@@ -29,7 +29,7 @@ def create_trainer_package(
 
     path_trainer = get_trainer_package_path(trainer_name=source_dir.name)
     name = name or path_trainer.stem
-    zip_path, package_files = archive_dir(source_dir, output_path=path_trainer)
+    zip_path, _ = archive_dir(source_dir, output_path=path_trainer)
     user_logger.info(f"Trainer package created and stored in '{path_trainer}'")
 
     cmd_builder_schemas = auto_discover_cmd_builder_schemas(source_dir)
@@ -106,7 +106,7 @@ def update_trainer_package(
     if source_dir is not None:
         source_dir = Path(source_dir).resolve()
         path_trainer = get_trainer_package_path(trainer_name=source_dir.name)
-        zip_path, package_files = archive_dir(source_dir, output_path=path_trainer)
+        zip_path, _ = archive_dir(source_dir, output_path=path_trainer)
         user_logger.info(f"Trainer package created and stored in '{path_trainer}'")
 
         cmd_builder_schemas = auto_discover_cmd_builder_schemas(source_dir)

--- a/src/hafnia/platform/trainer_package.py
+++ b/src/hafnia/platform/trainer_package.py
@@ -60,7 +60,11 @@ def auto_discover_cmd_builder_schemas(path_source: Path) -> List[Dict]:
     cmd_builder_schema_files = [f for f in path_source.rglob("*.schema.json") if ".venv" not in f.parts]
     cmd_builder_schemas = []
     for cmd_builder_schema_file in cmd_builder_schema_files:
-        cmd_builder_schema = json.loads(cmd_builder_schema_file.read_text())
+        try:
+            cmd_builder_schema = json.loads(cmd_builder_schema_file.read_text())
+        except json.JSONDecodeError:
+            user_logger.warning(f"Could not parse'{cmd_builder_schema_file}' as JSON. Skipping.")
+            continue
         required_fields = ["cmd", "json_schema"]
         missing_field = next((field for field in required_fields if field not in cmd_builder_schema), None)
         if missing_field is not None:

--- a/src/hafnia/platform/trainer_package.py
+++ b/src/hafnia/platform/trainer_package.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from hafnia import http
+from hafnia.experiment.command_builder import DEFAULT_ORDER
 from hafnia.log import user_logger
 from hafnia.utils import (
     archive_dir,
@@ -31,7 +32,7 @@ def create_trainer_package(
     zip_path, package_files = archive_dir(source_dir, output_path=path_trainer)
     user_logger.info(f"Trainer package created and stored in '{path_trainer}'")
 
-    cmd_builder_schemas = auto_discover_cmd_builder_schemas(package_files)
+    cmd_builder_schemas = auto_discover_cmd_builder_schemas(source_dir)
     cmd = cmd or "python scripts/train.py"
     description = description or f"Trainer package for '{name}'. Created with Hafnia SDK Cli."
     headers = {"Authorization": cfg.api_key, "accept": "application/json"}
@@ -49,18 +50,32 @@ def create_trainer_package(
     return response
 
 
-def auto_discover_cmd_builder_schemas(package_files: List[Path]) -> List[Dict]:
+def auto_discover_cmd_builder_schemas(path_source: Path) -> List[Dict]:
     """
     Auto-discover command builder schema files in the trainer package files.
     Looks for files ending with '.schema.json' and loads their content as JSON.
     """
-    cmd_builder_schema_files = [file for file in package_files if file.name.endswith(".schema.json")]
+    # Filter for '.schema.json' files, but drop '.schema.json' files in '.venv' directories as we have found that
+    # some python packages also use this suffix for their own config files
+    cmd_builder_schema_files = [f for f in path_source.rglob("*.schema.json") if ".venv" not in f.parts]
     cmd_builder_schemas = []
     for cmd_builder_schema_file in cmd_builder_schema_files:
         cmd_builder_schema = json.loads(cmd_builder_schema_file.read_text())
-        cmd_entrypoint = cmd_builder_schema.get("cmd", None)
+        required_fields = ["cmd", "json_schema"]
+        missing_field = next((field for field in required_fields if field not in cmd_builder_schema), None)
+        if missing_field is not None:
+            user_logger.warning(
+                f"One of the discovered command builder schema '{cmd_builder_schema_file}' is not considered "
+                f"a command builder schema because it is missing the '{missing_field}' field. "
+                "Skipping this file.",
+            )
+            continue
+        cmd_entrypoint = cmd_builder_schema["cmd"]
         user_logger.info(f"Found command builder schema file for entry point '{cmd_entrypoint}'")
         cmd_builder_schemas.append(cmd_builder_schema)
+
+    # Sort the schemas by the 'order' field, with missing 'order' treated as DEFAULT_ORDER
+    cmd_builder_schemas.sort(key=lambda s: s.get("order", DEFAULT_ORDER))
     return cmd_builder_schemas
 
 
@@ -94,7 +109,7 @@ def update_trainer_package(
         zip_path, package_files = archive_dir(source_dir, output_path=path_trainer)
         user_logger.info(f"Trainer package created and stored in '{path_trainer}'")
 
-        cmd_builder_schemas = auto_discover_cmd_builder_schemas(package_files)
+        cmd_builder_schemas = auto_discover_cmd_builder_schemas(source_dir)
         if len(cmd_builder_schemas) > 0:
             fields["command_builder_schemas"] = json.dumps(cmd_builder_schemas)
         fields["file"] = (zip_path.name, Path(zip_path).read_bytes())

--- a/src/hafnia/platform/trainer_package.py
+++ b/src/hafnia/platform/trainer_package.py
@@ -29,10 +29,10 @@ def create_trainer_package(
 
     path_trainer = get_trainer_package_path(trainer_name=source_dir.name)
     name = name or path_trainer.stem
-    zip_path, _ = archive_dir(source_dir, output_path=path_trainer)
+    zip_path, package_files = archive_dir(source_dir, output_path=path_trainer)
     user_logger.info(f"Trainer package created and stored in '{path_trainer}'")
 
-    cmd_builder_schemas = auto_discover_cmd_builder_schemas(source_dir)
+    cmd_builder_schemas = auto_discover_cmd_builder_schemas(package_files)
     cmd = cmd or "python scripts/train.py"
     description = description or f"Trainer package for '{name}'. Created with Hafnia SDK Cli."
     headers = {"Authorization": cfg.api_key, "accept": "application/json"}
@@ -50,20 +50,21 @@ def create_trainer_package(
     return response
 
 
-def auto_discover_cmd_builder_schemas(path_source: Path) -> List[Dict]:
+def auto_discover_cmd_builder_schemas(package_files: List[Path]) -> List[Dict]:
     """
     Auto-discover command builder schema files in the trainer package files.
     Looks for files ending with '.schema.json' and loads their content as JSON.
+
+    Only files that are part of the trainer package are considered, so '.schema.json' files excluded by
+    '.hafniaignore' (e.g. in '.venv' or other ignored directories) are not picked up.
     """
-    # Filter for '.schema.json' files, but drop '.schema.json' files in '.venv' directories as we have found that
-    # some python packages also use this suffix for their own config files
-    cmd_builder_schema_files = [f for f in path_source.rglob("*.schema.json") if ".venv" not in f.parts]
+    cmd_builder_schema_files = [file for file in package_files if file.name.endswith(".schema.json")]
     cmd_builder_schemas = []
     for cmd_builder_schema_file in cmd_builder_schema_files:
         try:
             cmd_builder_schema = json.loads(cmd_builder_schema_file.read_text())
         except json.JSONDecodeError:
-            user_logger.warning(f"Could not parse'{cmd_builder_schema_file}' as JSON. Skipping.")
+            user_logger.warning(f"Could not parse '{cmd_builder_schema_file}' as JSON. Skipping.")
             continue
         required_fields = ["cmd", "json_schema"]
         missing_field = next((field for field in required_fields if field not in cmd_builder_schema), None)
@@ -110,10 +111,10 @@ def update_trainer_package(
     if source_dir is not None:
         source_dir = Path(source_dir).resolve()
         path_trainer = get_trainer_package_path(trainer_name=source_dir.name)
-        zip_path, _ = archive_dir(source_dir, output_path=path_trainer)
+        zip_path, package_files = archive_dir(source_dir, output_path=path_trainer)
         user_logger.info(f"Trainer package created and stored in '{path_trainer}'")
 
-        cmd_builder_schemas = auto_discover_cmd_builder_schemas(source_dir)
+        cmd_builder_schemas = auto_discover_cmd_builder_schemas(package_files)
         if len(cmd_builder_schemas) > 0:
             fields["command_builder_schemas"] = json.dumps(cmd_builder_schemas)
         fields["file"] = (zip_path.name, Path(zip_path).read_bytes())

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -89,7 +89,7 @@ def test_cli_integration_test():
     with pytest.raises(MissingParameter):
         hafnia_cli(args=[CMD_TRAINER_PACKAGE, "update"], standalone_mode=False)
     with pytest.raises(click.UsageError):
-        hafnia_cli(args=[CMD_TRAINER_PACKAGE, "update", "non-existent-id"], standalone_mode=False)
+        hafnia_cli(args=[CMD_TRAINER_PACKAGE, "update", "non-existent-id", "--name", "Blah"], standalone_mode=False)
 
     # Experiment commands
     CMD_EXPERIMENT = "experiment"

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -1,6 +1,6 @@
-import click
 import pytest
 from click.exceptions import MissingParameter, NoArgsIsHelpError
+from urllib3.exceptions import HTTPError
 
 from hafnia import utils
 from hafnia.dataset.dataset_recipe.dataset_recipe import DatasetRecipe
@@ -88,7 +88,7 @@ def test_cli_integration_test():
     hafnia_cli(args=[CMD_TRAINER_PACKAGE, "update", "--help"], standalone_mode=False)
     with pytest.raises(MissingParameter):
         hafnia_cli(args=[CMD_TRAINER_PACKAGE, "update"], standalone_mode=False)
-    with pytest.raises(click.UsageError):
+    with pytest.raises(HTTPError, match="Not found"):
         hafnia_cli(args=[CMD_TRAINER_PACKAGE, "update", "non-existent-id", "--name", "Blah"], standalone_mode=False)
 
     # Experiment commands

--- a/tests/unit/test_command_builder.py
+++ b/tests/unit/test_command_builder.py
@@ -485,3 +485,54 @@ def test_enum_not_supported():
 
     with pytest.raises(TypeError, match="'Enum' CLI argument types are not supported yet"):
         command_builder.schema_from_cli_function(enum_parameter_example)
+
+
+def _write_schema(path: Path, name: str, schema: dict) -> Path:
+    schema_file = path / f"{name}.schema.json"
+    schema_file.write_text(json.dumps(schema))
+    return schema_file
+
+
+def test_auto_discover_cmd_builder_schemas_ordering(tmp_path: Path):
+    """Schemas are returned sorted by their 'order' field, missing 'order' treated as DEFAULT_ORDER."""
+    from hafnia.experiment.command_builder import DEFAULT_ORDER
+    from hafnia.platform.trainer_package import auto_discover_cmd_builder_schemas
+
+    _write_schema(tmp_path, "third", {"cmd": "third", "json_schema": {}, "order": 30})
+    _write_schema(tmp_path, "first", {"cmd": "first", "json_schema": {}, "order": 10})
+    _write_schema(tmp_path, "second", {"cmd": "second", "json_schema": {}, "order": 20})
+    # No 'order' field -> treated as DEFAULT_ORDER (100), so it sorts last here.
+    _write_schema(tmp_path, "no_order", {"cmd": "no_order", "json_schema": {}})
+
+    schemas = auto_discover_cmd_builder_schemas(tmp_path)
+
+    assert [s["cmd"] for s in schemas] == ["first", "second", "third", "no_order"]
+    assert DEFAULT_ORDER > 30  # sanity check that 'no_order' is expected to sort after the explicit orders
+
+
+def test_auto_discover_cmd_builder_schemas_skips_invalid(tmp_path: Path):
+    """Schemas missing a required field ('cmd' or 'json_schema') are skipped, valid ones are kept."""
+    from hafnia.platform.trainer_package import auto_discover_cmd_builder_schemas
+
+    _write_schema(tmp_path, "valid", {"cmd": "valid", "json_schema": {}})
+    _write_schema(tmp_path, "missing_cmd", {"json_schema": {}})
+    _write_schema(tmp_path, "missing_json_schema", {"cmd": "missing_json_schema"})
+    _write_schema(tmp_path, "empty", {})
+
+    schemas = auto_discover_cmd_builder_schemas(tmp_path)
+
+    assert [s["cmd"] for s in schemas] == ["valid"]
+
+
+def test_auto_discover_cmd_builder_schemas_ignores_venv(tmp_path: Path):
+    """'.schema.json' files inside a '.venv' directory are ignored."""
+    from hafnia.platform.trainer_package import auto_discover_cmd_builder_schemas
+
+    _write_schema(tmp_path, "valid", {"cmd": "valid", "json_schema": {}})
+    venv_dir = tmp_path / ".venv" / "some_package"
+    venv_dir.mkdir(parents=True)
+    _write_schema(venv_dir, "package_config", {"cmd": "package_config", "json_schema": {}})
+
+    schemas = auto_discover_cmd_builder_schemas(tmp_path)
+
+    assert [s["cmd"] for s in schemas] == ["valid"]

--- a/tests/unit/test_command_builder.py
+++ b/tests/unit/test_command_builder.py
@@ -197,7 +197,7 @@ def test_command_builder_schema(tmp_path: Path):
     path_schema_json = tmp_path / "command_schema.json"
     auto_save_command_builder_schema(
         name="Trainer",
-        n_positional_args=0,
+        positional_args=[],
         cli_function=cli_function_example,
         path_schema=path_schema_json,
     )
@@ -332,16 +332,16 @@ def test_command_args_from_form_data_simple():
     cmd_builder1 = CommandBuilderSchema.from_function(some_function)
     commands_args = cmd_builder1.command_args_from_form_data(form_dataset)
     cmd_string = " ".join(commands_args)
-    assert cmd_string.count(" --") == n_root_params - cmd_builder1.n_positional_args
+    assert cmd_string.count(" --") == n_root_params - len(cmd_builder1.positional_args)
     assert "nested.name" in cmd_string, "Nested parameter not correctly represented. Expected '.' separator."
     assert "param-value1" in cmd_string, "Parameter value was not converted to kebab-case."
     assert "--no-bool-flag1" in cmd_string, "Boolean flag not correctly represented with default settings."
     assert "--bool-flag2" in cmd_string, "Boolean flag with default True not correctly represented."
 
-    # Use case 2: Custom settings
+    # Use case 2: Custom settings, with 'param_value1' declared as a positional argument
     cmd_builder2 = CommandBuilderSchema.from_function(
         some_function,
-        n_positional_args=1,
+        positional_args=["param_value1"],
         parameter_prefix="++",
         nested_parameter_handling="dot",
         case_conversion="none",
@@ -351,7 +351,8 @@ def test_command_args_from_form_data_simple():
 
     commands_args = cmd_builder2.command_args_from_form_data(form_dataset)
     cmd_string = " ".join(commands_args)
-    assert cmd_string.count(" ++") == n_root_params - cmd_builder2.n_positional_args
+    assert cmd_builder2.positional_args == ["param_value1"], "Positional args not stored on the schema."
+    assert cmd_string.count(" ++") == n_root_params - len(cmd_builder2.positional_args)
     assert "nested.name" in cmd_string, "Nested parameter not correctly represented. Expected '.' separator."
     assert "param_value2" in cmd_string, "Parameter value was incorrectly converted to kebab-case."
     assert "++nested.name='some name'" in cmd_string, "Assignment separator '=' not correctly used."
@@ -359,6 +360,21 @@ def test_command_args_from_form_data_simple():
     assert "++bool_flag2=True" in cmd_string, (
         "Boolean flag with default True not correctly represented with flag-negation."
     )
+    # The positional argument is emitted first - as a bare value, before any '++' option.
+    assert commands_args[len(cmd_builder2.cmd.split(" "))] == "'custom_value'", (
+        "Positional argument should be emitted first as a bare value."
+    )
+    assert "++param_value1" not in cmd_string, "Positional argument should not be emitted as a named option."
+
+
+def test_positional_args_unknown_name_raises():
+    """A name in 'positional' that is not a parameter of the function must raise a ValueError."""
+
+    def some_function(param_value1: str, param_value2: int = 10) -> None:
+        return None
+
+    with pytest.raises(ValueError, match="positional_args"):
+        CommandBuilderSchema.from_function(some_function, positional_args=["does_not_exist"])
 
 
 def test_cyclopts_cmdline():

--- a/tests/unit/test_command_builder.py
+++ b/tests/unit/test_command_builder.py
@@ -368,7 +368,7 @@ def test_command_args_from_form_data_simple():
 
 
 def test_positional_args_unknown_name_raises():
-    """A name in 'positional' that is not a parameter of the function must raise a ValueError."""
+    """A name in 'positional_args' that is not a parameter of the function must raise a ValueError."""
 
     def some_function(param_value1: str, param_value2: int = 10) -> None:
         return None
@@ -514,41 +514,50 @@ def test_auto_discover_cmd_builder_schemas_ordering(tmp_path: Path):
     from hafnia.experiment.command_builder import DEFAULT_ORDER
     from hafnia.platform.trainer_package import auto_discover_cmd_builder_schemas
 
-    _write_schema(tmp_path, "third", {"cmd": "third", "json_schema": {}, "order": 30})
-    _write_schema(tmp_path, "first", {"cmd": "first", "json_schema": {}, "order": 10})
-    _write_schema(tmp_path, "second", {"cmd": "second", "json_schema": {}, "order": 20})
-    # No 'order' field -> treated as DEFAULT_ORDER (100), so it sorts last here.
-    _write_schema(tmp_path, "no_order", {"cmd": "no_order", "json_schema": {}})
+    package_files = [
+        _write_schema(tmp_path, "third", {"cmd": "third", "json_schema": {}, "order": 30}),
+        _write_schema(tmp_path, "first", {"cmd": "first", "json_schema": {}, "order": 10}),
+        _write_schema(tmp_path, "second", {"cmd": "second", "json_schema": {}, "order": 20}),
+        # No 'order' field -> treated as DEFAULT_ORDER (100), so it sorts last here.
+        _write_schema(tmp_path, "no_order", {"cmd": "no_order", "json_schema": {}}),
+    ]
 
-    schemas = auto_discover_cmd_builder_schemas(tmp_path)
+    schemas = auto_discover_cmd_builder_schemas(package_files)
 
     assert [s["cmd"] for s in schemas] == ["first", "second", "third", "no_order"]
     assert DEFAULT_ORDER > 30  # sanity check that 'no_order' is expected to sort after the explicit orders
 
 
 def test_auto_discover_cmd_builder_schemas_skips_invalid(tmp_path: Path):
-    """Schemas missing a required field ('cmd' or 'json_schema') are skipped, valid ones are kept."""
+    """Schemas missing a required field ('cmd' or 'json_schema'), or that are not valid JSON, are skipped."""
     from hafnia.platform.trainer_package import auto_discover_cmd_builder_schemas
 
-    _write_schema(tmp_path, "valid", {"cmd": "valid", "json_schema": {}})
-    _write_schema(tmp_path, "missing_cmd", {"json_schema": {}})
-    _write_schema(tmp_path, "missing_json_schema", {"cmd": "missing_json_schema"})
-    _write_schema(tmp_path, "empty", {})
+    malformed = tmp_path / "malformed.schema.json"
+    malformed.write_text("{not valid json")
 
-    schemas = auto_discover_cmd_builder_schemas(tmp_path)
+    package_files = [
+        _write_schema(tmp_path, "valid", {"cmd": "valid", "json_schema": {}}),
+        _write_schema(tmp_path, "missing_cmd", {"json_schema": {}}),
+        _write_schema(tmp_path, "missing_json_schema", {"cmd": "missing_json_schema"}),
+        _write_schema(tmp_path, "empty", {}),
+        malformed,
+    ]
+
+    schemas = auto_discover_cmd_builder_schemas(package_files)
 
     assert [s["cmd"] for s in schemas] == ["valid"]
 
 
-def test_auto_discover_cmd_builder_schemas_ignores_venv(tmp_path: Path):
-    """'.schema.json' files inside a '.venv' directory are ignored."""
+def test_auto_discover_cmd_builder_schemas_only_schema_json_files(tmp_path: Path):
+    """Only files ending with '.schema.json' are considered; other packaged files are ignored."""
     from hafnia.platform.trainer_package import auto_discover_cmd_builder_schemas
 
-    _write_schema(tmp_path, "valid", {"cmd": "valid", "json_schema": {}})
-    venv_dir = tmp_path / ".venv" / "some_package"
-    venv_dir.mkdir(parents=True)
-    _write_schema(venv_dir, "package_config", {"cmd": "package_config", "json_schema": {}})
+    schema_file = _write_schema(tmp_path, "valid", {"cmd": "valid", "json_schema": {}})
+    other_file = tmp_path / "train.py"
+    other_file.write_text("print('hello')")
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"cmd": "config", "json_schema": {}}))
 
-    schemas = auto_discover_cmd_builder_schemas(tmp_path)
+    schemas = auto_discover_cmd_builder_schemas([schema_file, other_file, config_file])
 
     assert [s["cmd"] for s in schemas] == ["valid"]

--- a/uv.lock
+++ b/uv.lock
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "hafnia"
-version = "0.7.9"
+version = "0.7.10"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Command builder adjustments:
- Adding order field to command builder to control the order command builer schemas appear. Main driver for doing this is to list the train.py command builder first 
- Use a list of positional arguments - instead of a number of positional arguments to make it more flexible. 

