### PR TITLE
In function load dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hafnia"
-version = "0.7.12"
+version = "0.7.13"
 description = "Python SDK for communication with Hafnia platform."
 readme = "README.md"
 authors = [

--- a/src/hafnia/experiment/hafnia_logger.py
+++ b/src/hafnia/experiment/hafnia_logger.py
@@ -16,13 +16,9 @@ from pydantic import BaseModel, field_validator
 from hafnia.log import sys_logger, user_logger
 from hafnia.utils import is_hafnia_cloud_job, now_as_str
 
-try:
-    import mlflow
-
-    MLFLOW_AVAILABLE = True
-except ImportError:
+MLFLOW_AVAILABLE = importlib.util.find_spec("mlflow") is not None
+if not MLFLOW_AVAILABLE:
     user_logger.warning("MLFlow is not available")
-    MLFLOW_AVAILABLE = False
 
 SYSTEM_METRICS_AVAILABLE = importlib.util.find_spec("psutil") is not None
 if not SYSTEM_METRICS_AVAILABLE:
@@ -118,6 +114,8 @@ class HafniaLogger:
     def _init_mlflow(self):
         """Initialize MLflow tracking for remote jobs."""
         try:
+            import mlflow
+
             # Set MLflow tracking URI from environment variable
             tracking_uri = os.getenv("MLFLOW_TRACKING_URI")
             if tracking_uri:
@@ -204,6 +202,8 @@ class HafniaLogger:
         if not self._mlflow_initialized:
             return
         try:
+            import mlflow
+
             mlflow.log_metric(name, value, step=step)
         except Exception as e:
             user_logger.error(f"Failed to log metric to MLflow: {e}")
@@ -226,6 +226,8 @@ class HafniaLogger:
             if not self._mlflow_initialized:
                 return
             try:
+                import mlflow
+
                 mlflow.log_params(params)
             except Exception as e:
                 user_logger.error(f"Failed to log params to MLflow: {e}")
@@ -272,6 +274,8 @@ class HafniaLogger:
         if not self._mlflow_initialized:
             return
         try:
+            import mlflow
+
             mlflow.end_run()
             self._mlflow_initialized = False
             user_logger.info("MLflow run ended successfully")

--- a/src/hafnia/platform/download.py
+++ b/src/hafnia/platform/download.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from typing import Dict, Optional
 
-import boto3
-from botocore.exceptions import ClientError
 from rich.progress import Progress
 
 from hafnia.http import fetch
@@ -75,6 +73,9 @@ def download_resource(resource_url: str, destination: str, api_key: str, prefix:
         ValueError: If the S3 ARN is invalid or no objects found under prefix.
         RuntimeError: If S3 calls fail with an unexpected error.
     """
+    import boto3
+    from botocore.exceptions import ClientError
+
     res_credentials = get_resource_credentials(resource_url, api_key)
 
     bucket_name = res_credentials.bucket_name()

--- a/src/hafnia/platform/s5cmd_utils.py
+++ b/src/hafnia/platform/s5cmd_utils.py
@@ -5,14 +5,15 @@ import sys
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
-import boto3
-from botocore.exceptions import UnauthorizedSSOTokenError
 from pydantic import BaseModel, field_validator
 
 from hafnia.log import sys_logger, user_logger
 from hafnia.utils import progress_bar
+
+if TYPE_CHECKING:
+    import boto3
 
 
 def find_s5cmd() -> Optional[str]:
@@ -185,10 +186,12 @@ class AwsCredentials(BaseModel):
         return environment_vars
 
     @staticmethod
-    def from_session(session: boto3.Session) -> "AwsCredentials":
+    def from_session(session: "boto3.Session") -> "AwsCredentials":
         """
         Creates AwsCredentials from a Boto3 session.
         """
+        from botocore.exceptions import UnauthorizedSSOTokenError
+
         try:
             frozen_credentials = session.get_credentials().get_frozen_credentials()
         except UnauthorizedSSOTokenError as e:

--- a/src/hafnia_cli/dataset_cmds.py
+++ b/src/hafnia_cli/dataset_cmds.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import click
 
-import hafnia.dataset.hafnia_dataset
 from hafnia import utils
 from hafnia_cli.config import Config
 
@@ -59,8 +58,9 @@ def cmd_dataset_download(
     cfg: Config, dataset_name: str, version: Optional[str], destination: Optional[click.Path], force: bool
 ) -> Path:
     """Download dataset from Hafnia platform"""
+    from hafnia.dataset.hafnia_dataset import download_or_get_dataset_path
 
-    path_dataset = hafnia.dataset.hafnia_dataset.download_or_get_dataset_path(
+    path_dataset = download_or_get_dataset_path(
         dataset_name=dataset_name,
         version=version,
         cfg=cfg,

--- a/src/hafnia_cli/experiment_cmds.py
+++ b/src/hafnia_cli/experiment_cmds.py
@@ -4,12 +4,6 @@ from typing import Dict, Optional
 import click
 
 from hafnia import utils
-from hafnia.platform.dataset_recipe import (
-    get_dataset_recipe_by_id,
-    get_dataset_recipe_by_name,
-    get_or_create_dataset_recipe_by_dataset_name,
-)
-from hafnia.platform.trainer_package import create_trainer_package
 from hafnia_cli.config import Config
 
 
@@ -201,6 +195,12 @@ def get_dataset_recipe_by_identifiers(
     recipe_name: Optional[str],
     recipe_id: Optional[str],
 ) -> Dict:
+    from hafnia.platform.dataset_recipe import (
+        get_dataset_recipe_by_id,
+        get_dataset_recipe_by_name,
+        get_or_create_dataset_recipe_by_dataset_name,
+    )
+
     dataset_identifiers = [dataset_name, recipe_name, recipe_id]
     n_dataset_identifies_defined = sum([bool(identifier) for identifier in dataset_identifiers])
 
@@ -235,6 +235,7 @@ def get_trainer_package_by_identifiers(
     trainer_id: Optional[str],
 ) -> str:
     from hafnia.platform import get_trainer_package_by_id
+    from hafnia.platform.trainer_package import create_trainer_package
 
     if trainer_path is not None and trainer_id is not None:
         raise click.ClickException(

--- a/uv.lock
+++ b/uv.lock
@@ -868,7 +868,7 @@ wheels = [
 
 [[package]]
 name = "hafnia"
-version = "0.7.12"
+version = "0.7.13"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Deferred heavy top-level imports (`mlflow`, `polars`/`cv2`, `boto3`) into the
  command callbacks that actually use them, so common commands no longer load the
  full SDK at startup

| Command | Before | After | Speedup |
  |---|---|---|---|
  | `hafnia profile ls` | 1214 ms | 225 ms | **5.4× faster** (−81%) |
  | `hafnia --help` | 1230 ms | 247 ms | **5.0× faster** (−80%) |
  | `hafnia experiment create --help` | 1238 ms | 258 ms | **4.8× faster** (−79%) |
  
  Goes after https://github.com/milestone-hafnia/hafnia/pull/207